### PR TITLE
Forward nested component context state

### DIFF
--- a/.changeset/short-goats-flash.md
+++ b/.changeset/short-goats-flash.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Forward render context in complete `Modal` and `Drawer` components

--- a/src/components/client/core/Drawer/Drawer.stories.tsx
+++ b/src/components/client/core/Drawer/Drawer.stories.tsx
@@ -21,6 +21,18 @@ export const Default: Story = {
   ),
 };
 
+export const WithContext: Story = {
+  render: () => (
+    <Drawer
+      trigger={<Button>Open Drawer</Button>}
+      title="Drawer Title"
+      description="Drawer Description"
+    >
+      {({ isOpen }) => <Text mt={2}>Open: {String(isOpen)}</Text>}
+    </Drawer>
+  ),
+};
+
 // TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
 const meta: Meta<typeof Drawer> = {
   title: "Client/Core/Drawer",

--- a/src/components/client/core/Drawer/Drawer.tsx
+++ b/src/components/client/core/Drawer/Drawer.tsx
@@ -22,7 +22,6 @@ export interface Props extends DrawerProps {
   placement?: "left" | "right";
   title?: string;
   description?: string;
-  children?: ReactNode;
 }
 
 /**
@@ -40,36 +39,49 @@ const Drawer = ({
 
   return (
     <PrimitiveDrawer {...rest}>
-      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-      <Portal>
-        <DrawerBackdrop className={classNames.backdrop} />
-        <DrawerContainer className={classNames.container}>
-          <DrawerContent lazyMount unmountOnExit className={classNames.content}>
-            {title && (
-              <DrawerTitle className={classNames.title}>{title}</DrawerTitle>
-            )}
-            {description && (
-              <DrawerDescription className={classNames.description}>
-                {description}
-              </DrawerDescription>
-            )}
-            {children}
-            <DrawerCloseTrigger
-              pos="absolute"
-              top={2}
-              right={2}
-              _focus={{
-                outline: "none",
-              }}
-              asChild
-            >
-              <Button bgColor={{ base: "inherit", _hover: "#f5f5f5" }}>
-                <Icon as={CloseIcon} color="black" />
-              </Button>
-            </DrawerCloseTrigger>
-          </DrawerContent>
-        </DrawerContainer>
-      </Portal>
+      {(ctx) => (
+        <>
+          <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+          <Portal>
+            <DrawerBackdrop className={classNames.backdrop} />
+            <DrawerContainer className={classNames.container}>
+              <DrawerContent
+                lazyMount
+                unmountOnExit
+                className={classNames.content}
+              >
+                {title && (
+                  <DrawerTitle className={classNames.title}>
+                    {title}
+                  </DrawerTitle>
+                )}
+                {description && (
+                  <DrawerDescription className={classNames.description}>
+                    {description}
+                  </DrawerDescription>
+                )}
+
+                {/* forward nested context/state if utilized, otherwise directly render children */}
+                {typeof children === "function" ? children(ctx) : children}
+
+                <DrawerCloseTrigger
+                  asChild
+                  pos="absolute"
+                  top={2}
+                  right={2}
+                  _focus={{
+                    outline: "none",
+                  }}
+                >
+                  <Button bgColor={{ base: "inherit", _hover: "#f5f5f5" }}>
+                    <Icon as={CloseIcon} color="black" />
+                  </Button>
+                </DrawerCloseTrigger>
+              </DrawerContent>
+            </DrawerContainer>
+          </Portal>
+        </>
+      )}
     </PrimitiveDrawer>
   );
 };

--- a/src/components/client/core/Modal/Modal.stories.tsx
+++ b/src/components/client/core/Modal/Modal.stories.tsx
@@ -21,6 +21,18 @@ export const Default: Story = {
   ),
 };
 
+export const WithContext: Story = {
+  render: () => (
+    <Modal
+      trigger={<Button>Open Modal</Button>}
+      title="Modal Title"
+      description="Modal Description"
+    >
+      {({ isOpen }) => <Text mt={2}>Open: {String(isOpen)}</Text>}
+    </Modal>
+  ),
+};
+
 // TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
 const meta: Meta<typeof Modal> = {
   title: "Client/Core/Modal",

--- a/src/components/client/core/Modal/Modal.tsx
+++ b/src/components/client/core/Modal/Modal.tsx
@@ -21,7 +21,6 @@ export interface Props extends ModalProps {
   trigger: ReactNode;
   title?: string;
   description?: string;
-  children?: ReactNode;
 }
 
 /**
@@ -32,36 +31,47 @@ const Modal = ({ children, trigger, title, description, ...rest }: Props) => {
 
   return (
     <PrimitiveModal {...rest}>
-      <ModalTrigger asChild>{trigger}</ModalTrigger>
-      <Portal>
-        <ModalBackdrop className={classNames.backdrop} />
-        <ModalContainer className={classNames.container}>
-          <ModalContent lazyMount unmountOnExit className={classNames.content}>
-            {title && (
-              <ModalTitle className={classNames.title}>{title}</ModalTitle>
-            )}
-            {description && (
-              <ModalDescription className={classNames.description}>
-                {description}
-              </ModalDescription>
-            )}
-            {children}
-            <ModalCloseTrigger
-              pos="absolute"
-              top={2}
-              right={2}
-              _focus={{
-                outline: "none",
-              }}
-              asChild
-            >
-              <Button bgColor={{ base: "inherit", _hover: "#f5f5f5" }}>
-                <Icon as={CloseIcon} color="black" />
-              </Button>
-            </ModalCloseTrigger>
-          </ModalContent>
-        </ModalContainer>
-      </Portal>
+      {(ctx) => (
+        <>
+          <ModalTrigger asChild>{trigger}</ModalTrigger>
+          <Portal>
+            <ModalBackdrop className={classNames.backdrop} />
+            <ModalContainer className={classNames.container}>
+              <ModalContent
+                lazyMount
+                unmountOnExit
+                className={classNames.content}
+              >
+                {title && (
+                  <ModalTitle className={classNames.title}>{title}</ModalTitle>
+                )}
+                {description && (
+                  <ModalDescription className={classNames.description}>
+                    {description}
+                  </ModalDescription>
+                )}
+
+                {/* forward nested context/state if utilized, otherwise directly render children */}
+                {typeof children === "function" ? children(ctx) : children}
+
+                <ModalCloseTrigger
+                  pos="absolute"
+                  top={2}
+                  right={2}
+                  _focus={{
+                    outline: "none",
+                  }}
+                  asChild
+                >
+                  <Button bgColor={{ base: "inherit", _hover: "#f5f5f5" }}>
+                    <Icon as={CloseIcon} color="black" />
+                  </Button>
+                </ModalCloseTrigger>
+              </ModalContent>
+            </ModalContainer>
+          </Portal>
+        </>
+      )}
     </PrimitiveModal>
   );
 };


### PR DESCRIPTION
## Description

##### Task link: N/A

- Patched complete `Drawer` and `Modal` components to forward their Ark render context
- Thanks to @hobbescodes for reporting the issue and working through a solution for this with me!

## Test Steps

- Verify components are usable, without type errors, with and without usage of the nested context
- Verify `WithContext` stories correctly indicate `isOpen` state for both components
