### PR TITLE
Fix Hide and Show Component Recipes

### DIFF
--- a/src/components/universal/utility/Hide/Hide.recipe.ts
+++ b/src/components/universal/utility/Hide/Hide.recipe.ts
@@ -3,7 +3,6 @@ import { defineRecipe } from "@pandacss/dev";
 export const hideRecipe = defineRecipe({
   className: "hide",
   description: "The styles for the Hide component",
-  // TODO: fix variants when `hideBelow` issue is fixed upstream (panda)
   variants: {
     from: {
       sm: {
@@ -23,17 +22,20 @@ export const hideRecipe = defineRecipe({
       },
     },
     below: {
-      md: {
+      sm: {
         hideBelow: "sm",
       },
-      lg: {
+      md: {
         hideBelow: "md",
       },
-      xl: {
+      lg: {
         hideBelow: "lg",
       },
-      "2xl": {
+      xl: {
         hideBelow: "xl",
+      },
+      "2xl": {
+        hideBelow: "2xl",
       },
     },
   },

--- a/src/components/universal/utility/Hide/Hide.stories.tsx
+++ b/src/components/universal/utility/Hide/Hide.stories.tsx
@@ -21,7 +21,7 @@ export const HideBelow: Story = {
         <Text>Hidden at and below xl breakpoint (1280px)</Text>
       </Hide>
       <Hide below="2xl">
-        <Text>Hidden at and 2xl breakpoint (1536px)</Text>
+        <Text>Hidden at and below 2xl breakpoint (1536px)</Text>
       </Hide>
     </Flex>
   ),

--- a/src/components/universal/utility/Hide/Hide.stories.tsx
+++ b/src/components/universal/utility/Hide/Hide.stories.tsx
@@ -8,17 +8,20 @@ type Story = StoryObj<typeof Hide>;
 export const HideBelow: Story = {
   render: () => (
     <Flex direction="column" gap={2}>
+      <Hide below="sm">
+        <Text>Hidden at and below sm breakpoint (640px)</Text>
+      </Hide>
       <Hide below="md">
-        <Text>Hidden below md breakpoint (768px)</Text>
+        <Text>Hidden at and below md breakpoint (768px)</Text>
       </Hide>
       <Hide below="lg">
-        <Text>Hidden below lg breakpoint (1024px)</Text>
+        <Text>Hidden at and below lg breakpoint (1024px)</Text>
       </Hide>
       <Hide below="xl">
-        <Text>Hidden below xl breakpoint (1280px)</Text>
+        <Text>Hidden at and below xl breakpoint (1280px)</Text>
       </Hide>
       <Hide below="2xl">
-        <Text>Hidden from 2xl breakpoint (1536px)</Text>
+        <Text>Hidden at and 2xl breakpoint (1536px)</Text>
       </Hide>
     </Flex>
   ),

--- a/src/components/universal/utility/Show/Show.recipe.ts
+++ b/src/components/universal/utility/Show/Show.recipe.ts
@@ -3,20 +3,22 @@ import { defineRecipe } from "@pandacss/dev";
 export const showRecipe = defineRecipe({
   className: "show",
   description: "The styles for the Show component",
-  // TODO: fix variants when `hideBelow` issue is fixed upstream (panda)
   variants: {
     from: {
-      md: {
+      sm: {
         hideBelow: "sm",
       },
-      lg: {
+      md: {
         hideBelow: "md",
       },
-      xl: {
+      lg: {
         hideBelow: "lg",
       },
-      "2xl": {
+      xl: {
         hideBelow: "xl",
+      },
+      "2xl": {
+        hideBelow: "2xl",
       },
     },
     below: {

--- a/src/components/universal/utility/Show/Show.stories.tsx
+++ b/src/components/universal/utility/Show/Show.stories.tsx
@@ -43,7 +43,7 @@ export const ShowBelow: Story = {
         <Text>Shown below xl breakpoint (1280px)</Text>
       </Show>
       <Show below="2xl">
-        <Text>Shown from 2xl breakpoint (1536px)</Text>
+        <Text>Shown below 2xl breakpoint (1536px)</Text>
       </Show>
     </Flex>
   ),

--- a/src/components/universal/utility/Show/Show.stories.tsx
+++ b/src/components/universal/utility/Show/Show.stories.tsx
@@ -8,17 +8,20 @@ type Story = StoryObj<typeof Show>;
 export const ShowFrom: Story = {
   render: () => (
     <Flex direction="column" gap={2}>
+      <Show from="sm">
+        <Text>Shown above sm breakpoint (640px)</Text>
+      </Show>
       <Show from="md">
-        <Text>Shown from md breakpoint and above (768px)</Text>
+        <Text>Shown above md breakpoint (768px)</Text>
       </Show>
       <Show from="lg">
-        <Text>Shown from lg breakpoint and above (1024px)</Text>
+        <Text>Shown above lg breakpoint (1024px)</Text>
       </Show>
       <Show from="xl">
-        <Text>Shown from xl breakpoint and above (1280px)</Text>
+        <Text>Shown above xl breakpoint (1280px)</Text>
       </Show>
       <Show from="2xl">
-        <Text>Shown from 2xl breakpoint and above (1536px)</Text>
+        <Text>Shown above 2xl breakpoint (1536px)</Text>
       </Show>
     </Flex>
   ),


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/INFjvC0M/198-fix-show-and-hide-recipe-breakpoints

Updated `Hide` and `Show` recipes and stories to match breakpoint value changes made [upstream](https://github.com/chakra-ui/panda/pull/1324) by PandaCSS.

## Test Steps

1) Verify `Hide` and `Show` components are responsive on correct breakpoints.
