### PR TITLE
`useBreakpoint` and `useBreakpointValue` hooks

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,4 +1,6 @@
+export { default as useBreakpoint } from "./useBreakpoint/useBreakpoint";
 export { default as useDisclosure } from "./useDisclosure/useDisclosure";
 export { default as useIsMounted } from "./useIsMounted";
 
-export type { Props as UseDisclosureProps } from "./useDisclosure/useDisclosure";
+export type { Options as UseBreakpointOptions } from "./useBreakpoint/useBreakpoint";
+export type { Options as UseDisclosureOptions } from "./useDisclosure/useDisclosure";

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,6 +1,8 @@
 export { default as useBreakpoint } from "./useBreakpoint/useBreakpoint";
+export { default as useBreakpointValue } from "./useBreakpointValue/useBreakpointValue";
 export { default as useDisclosure } from "./useDisclosure/useDisclosure";
 export { default as useIsMounted } from "./useIsMounted";
 
 export type { Options as UseBreakpointOptions } from "./useBreakpoint/useBreakpoint";
+export type { Options as UseBreakpointValueOptions } from "./useBreakpointValue/useBreakpointValue";
 export type { Options as UseDisclosureOptions } from "./useDisclosure/useDisclosure";

--- a/src/lib/hooks/useBreakpoint/useBreakpoint.stories.tsx
+++ b/src/lib/hooks/useBreakpoint/useBreakpoint.stories.tsx
@@ -1,0 +1,42 @@
+import { Text } from "components/universal";
+import { panda } from "generated/panda/jsx";
+import { token } from "generated/panda/tokens";
+import { useBreakpoint } from "lib/hooks";
+
+import type { Meta, StoryObj } from "@storybook/react";
+import type { UseBreakpointOptions } from "lib/hooks";
+
+type Story = StoryObj<typeof useBreakpoint>;
+
+// TODO add viewport-based client stories (can use https://storybook.js.org/docs/react/essentials/viewport); https://trello.com/c/6cKY4EDk/201-hook-tests
+
+// TODO add custom fallback story with mocked undefined window to simulate server environment; https://trello.com/c/6cKY4EDk/201-hook-tests
+/**
+ * The "base" breakpoint is used as a fallback by default. This can be overridden by setting `fallback`.
+ */
+// export const WithCustomFallback: Story = { ... };
+
+const BreakpointExample = ({ fallback }: UseBreakpointOptions) => {
+  const breakpoint = useBreakpoint({ fallback });
+
+  return (
+    <Text>
+      <panda.span fontWeight="bold">Current breakpoint:</panda.span>{" "}
+      {breakpoint} ({token(`breakpoints.${breakpoint}`)})
+    </Text>
+  );
+};
+
+export const Default: Story = {
+  render: () => <BreakpointExample />,
+};
+
+// TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
+const meta: Meta<typeof useBreakpoint> = {
+  title: "Hooks/useBreakpoint",
+  tags: ["autodocs"],
+  component: useBreakpoint,
+  decorators: [(Story) => <Story />],
+} satisfies Meta<typeof useBreakpoint>;
+
+export default meta;

--- a/src/lib/hooks/useBreakpoint/useBreakpoint.tsx
+++ b/src/lib/hooks/useBreakpoint/useBreakpoint.tsx
@@ -10,12 +10,16 @@ interface WindowDimensions {
   height: typeof window.innerHeight;
 }
 
+export interface Options {
+  /** Fallback breakpoint to use if no match is found, or if `window` is undefined as in server-side contexts. Defaults to "base". */
+  fallback?: BreakpointToken;
+}
+
 /**
  * Get the current theme breakpoint.
  */
-// TODO add fallback support (especially useful for SSR)
-const useBreakpoint = () => {
-  const [breakpoint, setBreakpoint] = useState<BreakpointToken>("base"),
+const useBreakpoint = ({ fallback = "base" }: Options = {}) => {
+  const [breakpoint, setBreakpoint] = useState<BreakpointToken>(fallback),
     [windowDimensions, setWindowDimensions] = useState<WindowDimensions>({
       width: 0,
       height: 0,

--- a/src/lib/hooks/useBreakpoint/useBreakpoint.tsx
+++ b/src/lib/hooks/useBreakpoint/useBreakpoint.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+
+import { breakpoints } from "lib/panda";
+import { emToPx } from "lib/utils";
+
+import type { BreakpointToken } from "generated/panda/tokens";
+
+interface WindowDimensions {
+  width: typeof window.innerWidth;
+  height: typeof window.innerHeight;
+}
+
+/**
+ * Get the current theme breakpoint.
+ */
+// TODO add fallback support (especially useful for SSR)
+const useBreakpoint = () => {
+  const [breakpoint, setBreakpoint] = useState<BreakpointToken>("base"),
+    [windowDimensions, setWindowDimensions] = useState<WindowDimensions>({
+      width: 0,
+      height: 0,
+    });
+
+  const handleResize = () => {
+    setWindowDimensions({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEffect(() => {
+    // attach listener to window `resize` event
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    // create tuple mapping of semantic breakpoint keys with their values
+    const range = Object.entries(breakpoints)
+      .map(([key, breakpoint]) => [key, emToPx(breakpoint as `${number}em`)])
+      // reverse to set largest breakpoint at the start (top-down; decreasing order)
+      .reverse();
+
+    setBreakpoint(
+      // find the first "floored" breakpoint below the window width
+      range.find(
+        ([, breakpoint]) => +breakpoint <= windowDimensions.width,
+      )?.[0] as BreakpointToken,
+    );
+
+    // clean up listener
+    return () => window.removeEventListener("resize", handleResize);
+  }, [windowDimensions.width]);
+
+  return breakpoint;
+};
+
+export default useBreakpoint;

--- a/src/lib/hooks/useBreakpointValue/useBreakpointValue.stories.tsx
+++ b/src/lib/hooks/useBreakpointValue/useBreakpointValue.stories.tsx
@@ -1,0 +1,58 @@
+import { Text } from "components/universal";
+import { Box, HStack, Stack } from "generated/panda/jsx";
+import { useBreakpoint, useBreakpointValue } from "lib/hooks";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+type Story = StoryObj<typeof useBreakpointValue>;
+
+const BreakpointValueExample = () => {
+  const color = useBreakpointValue({
+    base: "red",
+    sm: "blue",
+    lg: "green",
+  });
+
+  const breakpoint = useBreakpoint();
+
+  return (
+    <HStack gap={4}>
+      <Box
+        w={40}
+        h={40}
+        p={4}
+        textAlign="center"
+        color="bg.default"
+        fontWeight="bold"
+        style={{ backgroundColor: color }}
+      >
+        Current breakpoint: {breakpoint}
+      </Box>
+
+      <Stack gap={1}>
+        <Text fontWeight="bold">Box Color</Text>
+        <Text color="red">[base → sm): red</Text>
+        <Text color="blue">[sm → lg): blue</Text>
+        <Text color="green">[lg → &#x1d461;]: green</Text>
+        &#x1d461; is any breakpoint token above lg
+      </Stack>
+    </HStack>
+  );
+};
+
+/**
+ * As an example, a `Box` background color can be set based on the current breakpoint.
+ */
+export const Default: Story = {
+  render: () => <BreakpointValueExample />,
+};
+
+// TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
+const meta: Meta<typeof useBreakpointValue> = {
+  title: "Hooks/useBreakpointValue",
+  tags: ["autodocs"],
+  component: useBreakpointValue,
+  decorators: [(Story) => <Story />],
+} satisfies Meta<typeof useBreakpointValue>;
+
+export default meta;

--- a/src/lib/hooks/useBreakpointValue/useBreakpointValue.tsx
+++ b/src/lib/hooks/useBreakpointValue/useBreakpointValue.tsx
@@ -1,0 +1,51 @@
+import useBreakpoint from "../useBreakpoint/useBreakpoint";
+import { breakpoints as defaultBreakpoints } from "lib/panda";
+
+import type { BreakpointToken } from "generated/panda/tokens";
+
+/**
+ * Get the closest value to the current breakpoint. This logic is taken from Chakra UI's `getClosestValue` function.
+ * @see https://github.com/chakra-ui/chakra-ui/blob/bd3d0fd2f444be2ba23764d7c86906cb488fb409/packages/components/media-query/src/media-query.utils.ts#L3-L32
+ * @param values The arbitrary values to compare against.
+ * @param breakpoint The current breakpoint.
+ * @returns The closest value to the current breakpoint.
+ */
+const getClosestValue = <T,>(values: Record<string, T>, breakpoint: string) => {
+  const breakpoints = Object.keys(defaultBreakpoints);
+
+  let index = Object.keys(values).indexOf(breakpoint);
+
+  if (index !== -1) return values[breakpoint];
+
+  let stopIndex = breakpoints.indexOf(breakpoint);
+
+  while (stopIndex >= 0) {
+    const key = breakpoints[stopIndex];
+
+    if (values.hasOwnProperty(key)) {
+      index = stopIndex;
+      break;
+    }
+    stopIndex -= 1;
+  }
+
+  if (index !== -1) {
+    const key = breakpoints[index];
+    return values[key];
+  }
+
+  return undefined;
+};
+
+export type Options<V> = Partial<Record<BreakpointToken, V>>;
+
+/**
+ * Get conditional value based on theme breakpoints.
+ */
+const useBreakpointValue = <V,>(values: Options<V>): V | undefined => {
+  const breakpoint = useBreakpoint();
+
+  return getClosestValue(values, breakpoint);
+};
+
+export default useBreakpointValue;

--- a/src/lib/hooks/useDisclosure/useDisclosure.stories.tsx
+++ b/src/lib/hooks/useDisclosure/useDisclosure.stories.tsx
@@ -3,8 +3,9 @@ import { Text } from "components/universal";
 import { useDisclosure } from "lib/hooks";
 
 import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentType } from "react";
 
-type Story = StoryObj<typeof Modal>;
+type Story = StoryObj<typeof useDisclosure>;
 
 const DisclosureExample = () => {
   const { isOpen, onOpen, onClose } = useDisclosure({});
@@ -28,11 +29,12 @@ export const Default: Story = {
 };
 
 // TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
-const meta: Meta<typeof Modal> = {
+const meta: Meta<typeof useDisclosure> = {
   title: "Hooks/useDisclosure",
-  component: Modal,
   tags: ["autodocs"],
+  // NB: type coercion here to allow `useDisclosure` Storybook metadata to render (e.g. JSDoc, hook parameters)
+  component: useDisclosure as unknown as ComponentType,
   decorators: [(Story) => <Story />],
-} satisfies Meta<typeof Modal>;
+} satisfies Meta<typeof useDisclosure>;
 
 export default meta;

--- a/src/lib/hooks/useDisclosure/useDisclosure.tsx
+++ b/src/lib/hooks/useDisclosure/useDisclosure.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 
-export interface Props {
+export interface Options {
   isOpen?: boolean;
   defaultIsOpen?: boolean;
   onOpen?: () => void;
@@ -12,7 +12,7 @@ const useDisclosure = ({
   defaultIsOpen,
   onOpen: onOpenProp,
   onClose: onCloseProp,
-}: Props) => {
+}: Options) => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen || false);
   const isControlled = isOpenProp !== undefined;
 

--- a/src/lib/hooks/useDisclosure/useDisclosure.tsx
+++ b/src/lib/hooks/useDisclosure/useDisclosure.tsx
@@ -7,6 +7,9 @@ export interface Options {
   onClose?: () => void;
 }
 
+/**
+ * Manage boolean disclosure state. Useful for modals, dropdowns, tooltips, and other components that can be toggled open/closed.
+ */
 const useDisclosure = ({
   isOpen: isOpenProp,
   defaultIsOpen,

--- a/src/lib/panda/aniref.preset.ts
+++ b/src/lib/panda/aniref.preset.ts
@@ -2,6 +2,7 @@ import { definePreset, defineTokens } from "@pandacss/dev";
 
 import {
   animations,
+  breakpoints,
   colors,
   conditions,
   easings,
@@ -31,6 +32,7 @@ const anirefPreset: ReturnType<typeof definePreset> = definePreset({
   globalCss,
   theme: {
     extend: {
+      breakpoints,
       keyframes,
       recipes,
       semanticTokens,

--- a/src/lib/panda/breakpoints.ts
+++ b/src/lib/panda/breakpoints.ts
@@ -1,0 +1,13 @@
+/**
+ * Device breakpoints for responsive design.
+ */
+const breakpoints = {
+  base: "0em",
+  sm: "40em",
+  md: "48em",
+  lg: "64em",
+  xl: "80em",
+  "2xl": "96em",
+};
+
+export default breakpoints;

--- a/src/lib/panda/index.ts
+++ b/src/lib/panda/index.ts
@@ -1,4 +1,5 @@
 export { default as animations } from "./animations";
+export { default as breakpoints } from "./breakpoints";
 export { default as colors } from "./colors";
 export { default as conditions } from "./conditions";
 export { default as easings } from "./easings";

--- a/src/lib/utils/emToPx.ts
+++ b/src/lib/utils/emToPx.ts
@@ -1,0 +1,9 @@
+/**
+ * Convert a relative `em` value to a pixel (`px`) value.
+ * @param em The `em` value to convert.
+ * @param base The base pixel value to use for the conversion. Defaults to `16px`.
+ * @returns The converted `px` value.
+ */
+const emToPx = (em: `${number}em`, base = 16) => +em.split("em")[0] * base;
+
+export default emToPx;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,2 +1,3 @@
+export { default as emToPx } from "./emToPx";
 export { default as getChildrenOnDisplayName } from "./getChildrenOnDisplayName";
 export { default as sleep } from "./sleep";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -47,8 +47,13 @@ const tsupConfig = defineTsupConfig({
     // https://esbuild.github.io/api/#resolve-extensions
     const defaultExtensions = [".tsx", ".ts", ".jsx", ".js", ".css", ".json"];
 
+    // filter out extensions from `esbuild` defaults
+    const selectedDefaultExtensions = defaultExtensions.filter(
+      (ext) => ![".css", ".json"].includes(ext),
+    );
+
     // extend recognized extensions to include explicit ESM extensions
-    opt.resolveExtensions = [...defaultExtensions, ".mts", ".mjs"];
+    opt.resolveExtensions = [...selectedDefaultExtensions, ".mts", ".mjs"];
   },
   onSuccess: async () => {
     console.log("Generating type declarations...");


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/oxQjYI04/182-usebreakpointvalue-hook

- Added `useBreakpoint` hook for dynamically based on window width
  - For non-browser runtime environments (such as Node.js), a fallback can be supplied with a default of the `base` breakpoint
- Added `useBreakpointValue` hook for setting any arbitrary runtime value based on the calculated breakpoint
- Extracted default Panda theme breakpoints into dedicated theme extension
 
Both `useBreakpoint` and `useBreakpointValue` were inspired by [Chakra UI](https://chakra-ui.com/).

## Test Steps

- Verify extracted breakpoints are at parity with Panda, they are modeled after https://github.com/chakra-ui/panda/pull/1324/files
- Test `useBreakpoint` behaves as expected (in Storybook, it should display the correct breakpoint at varying window widths, you can manually adjust window to test)
- Test `useBreakpointValue` behaves as expected (in the story I created, there is a legend that shows what color a box should be at varying breakpoint ranges)

Thorough automated testing, including edge cases, will be implemented in https://trello.com/c/6cKY4EDk/201-hook-tests.
