### PR TITLE
Pass Default Options to `useDisclosure` Hook

### DIFF
--- a/.changeset/great-taxis-dress.md
+++ b/.changeset/great-taxis-dress.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Add default `{}` options to `useDisclosure` hook

--- a/src/lib/hooks/useDisclosure/useDisclosure.stories.tsx
+++ b/src/lib/hooks/useDisclosure/useDisclosure.stories.tsx
@@ -8,7 +8,7 @@ import type { ComponentType } from "react";
 type Story = StoryObj<typeof useDisclosure>;
 
 const DisclosureExample = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure({});
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Modal

--- a/src/lib/hooks/useDisclosure/useDisclosure.tsx
+++ b/src/lib/hooks/useDisclosure/useDisclosure.tsx
@@ -11,30 +11,30 @@ export interface Options {
  * Manage boolean disclosure state. Useful for modals, dropdowns, tooltips, and other components that can be toggled open/closed.
  */
 const useDisclosure = ({
-  isOpen: isOpenProp,
+  isOpen: isOpenOption,
   defaultIsOpen,
-  onOpen: onOpenProp,
-  onClose: onCloseProp,
+  onOpen: onOpenOption,
+  onClose: onCloseOption,
 }: Options = {}) => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen || false);
-  const isControlled = isOpenProp !== undefined;
+  const isControlled = isOpenOption !== undefined;
 
   const onClose = useCallback(() => {
     !isControlled && setIsOpen(false);
-    onCloseProp && onCloseProp();
-  }, [isControlled, onCloseProp]);
+    onCloseOption && onCloseOption();
+  }, [isControlled, onCloseOption]);
 
   const onOpen = useCallback(() => {
     !isControlled && setIsOpen(true);
-    onOpenProp && onOpenProp();
-  }, [isControlled, onOpenProp]);
+    onOpenOption && onOpenOption();
+  }, [isControlled, onOpenOption]);
 
   const onToggle = useCallback(() => {
-    !isControlled ? setIsOpen(!isOpen) : isOpenProp ? onClose() : onOpen();
-  }, [isControlled, isOpen, isOpenProp, onClose, onOpen]);
+    !isControlled ? setIsOpen(!isOpen) : isOpenOption ? onClose() : onOpen();
+  }, [isControlled, isOpen, isOpenOption, onClose, onOpen]);
 
   return {
-    isOpen: isControlled ? isOpenProp : isOpen,
+    isOpen: isControlled ? isOpenOption : isOpen,
     onOpen,
     onClose,
     onToggle,

--- a/src/lib/hooks/useDisclosure/useDisclosure.tsx
+++ b/src/lib/hooks/useDisclosure/useDisclosure.tsx
@@ -15,7 +15,7 @@ const useDisclosure = ({
   defaultIsOpen,
   onOpen: onOpenProp,
   onClose: onCloseProp,
-}: Options) => {
+}: Options = {}) => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen || false);
   const isControlled = isOpenProp !== undefined;
 


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/p4GkmSQv/202-pass-default-options-to-usedisclosure

Updated `useDisclosure` hook to include default `{}` options and renamed all instances of `Prop` --> `Option` for naming convention consistency.

## Test Steps

1) Verify structure of hook is sound.
