### PR TITLE
Update `Flyout` title prop type from `string` --> `ReactNode`

### DIFF
--- a/.changeset/light-pumpkins-protect.md
+++ b/.changeset/light-pumpkins-protect.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Update `Flyout` title prop typing from `string` to `ReactNode`

--- a/src/components/client/core/Flyout/Flyout.tsx
+++ b/src/components/client/core/Flyout/Flyout.tsx
@@ -22,7 +22,7 @@ import type { ReactNode } from "react";
 
 export interface Props extends FlyoutProps {
   trigger: ReactNode;
-  title?: string;
+  title?: ReactNode;
   children: ReactNode;
 }
 


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/gYLA3VFi/205-change-flyout-title-prop-type-from-string-to-reactnode

Updated `title` prop type.

## Test Steps

1) Verify it is updated.
