### PR TITLE
Remove `as` prop usage for `Icon` component

### DIFF
--- a/.changeset/tender-planets-worry.md
+++ b/.changeset/tender-planets-worry.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": minor
+---
+
+Refactor `Icon` component by removing `as` prop usage"

--- a/examples/next/src/components/BreadcrumbDemo.tsx
+++ b/examples/next/src/components/BreadcrumbDemo.tsx
@@ -17,11 +17,9 @@ const BreadcrumbDemo = () => {
       <Breadcrumb
         breadcrumbs={BREADCRUMBS}
         separator={
-          <Icon
-            as={ChevronRightIcon}
-            color="accent.emphasized"
-            aria-label="separator-icon"
-          />
+          <Icon color="accent.emphasized" aria-label="separator-icon">
+            <ChevronRightIcon />
+          </Icon>
         }
       />
     </Wrapper>

--- a/examples/next/src/components/IconDemo.tsx
+++ b/examples/next/src/components/IconDemo.tsx
@@ -13,16 +13,24 @@ const IconDemo = () => (
   <Wrapper title="Icon">
     <Flex gap={2}>
       <Flex bgColor="red.100" p={2} borderRadius="md">
-        <Icon as={FiHeart} color="red.500" />
+        <Icon color="red.500">
+          <FiHeart />
+        </Icon>
       </Flex>
       <Flex bgColor="blue.100" p={2} borderRadius="md">
-        <Icon as={FiCheck} color="blue.500" />
+        <Icon color="blue.500">
+          <FiCheck />
+        </Icon>
       </Flex>
       <Flex bgColor="gray.100" p={2} borderRadius="md">
-        <Icon as={FiExternalLink} color="gray.500" />
+        <Icon color="gray.500">
+          <FiExternalLink />
+        </Icon>
       </Flex>
       <Flex bgColor="yellow.100" p={2} borderRadius="md">
-        <Icon as={FiAlertTriangle} color="yellow.500" />
+        <Icon color="yellow.500">
+          <FiAlertTriangle />
+        </Icon>
       </Flex>
     </Flex>
   </Wrapper>

--- a/examples/vite-react/src/components/BreadcrumbDemo.tsx
+++ b/examples/vite-react/src/components/BreadcrumbDemo.tsx
@@ -17,11 +17,9 @@ const BreadcrumbDemo = () => {
       <Breadcrumb
         breadcrumbs={BREADCRUMBS}
         separator={
-          <Icon
-            as={ChevronRightIcon}
-            color="accent.emphasized"
-            aria-label="separator-icon"
-          />
+          <Icon color="accent.emphasized" aria-label="separator-icon">
+            <ChevronRightIcon />
+          </Icon>
         }
       />
     </Wrapper>

--- a/examples/vite-react/src/components/IconDemo.tsx
+++ b/examples/vite-react/src/components/IconDemo.tsx
@@ -13,16 +13,24 @@ const IconDemo = () => (
   <Wrapper title="Icon">
     <Flex gap={2}>
       <Flex bgColor="red.100" p={2} borderRadius="md">
-        <Icon as={FiHeart} color="red.500" />
+        <Icon color="red.500">
+          <FiHeart />
+        </Icon>
       </Flex>
       <Flex bgColor="blue.100" p={2} borderRadius="md">
-        <Icon as={FiCheck} color="blue.500" />
+        <Icon color="blue.500">
+          <FiCheck />
+        </Icon>
       </Flex>
       <Flex bgColor="gray.100" p={2} borderRadius="md">
-        <Icon as={FiExternalLink} color="gray.500" />
+        <Icon color="gray.500">
+          <FiExternalLink />
+        </Icon>
       </Flex>
       <Flex bgColor="yellow.100" p={2} borderRadius="md">
-        <Icon as={FiAlertTriangle} color="yellow.500" />
+        <Icon color="yellow.500">
+          <FiAlertTriangle />
+        </Icon>
       </Flex>
     </Flex>
   </Wrapper>

--- a/src/components/client/core/Accordion/Accordion.tsx
+++ b/src/components/client/core/Accordion/Accordion.tsx
@@ -64,7 +64,7 @@ const Accordion = ({ items, plusMinus, ...rest }: Props) => {
                         <PlusIcon />
                       )
                     ) : (
-                      (icon as ReactElement) ?? <ChevronDownIcon />
+                      icon ?? <ChevronDownIcon />
                     )}
                   </Icon>
                 </Button>

--- a/src/components/client/core/Accordion/Accordion.tsx
+++ b/src/components/client/core/Accordion/Accordion.tsx
@@ -15,14 +15,14 @@ import {
 import { accordion } from "generated/panda/recipes";
 
 import type { AccordionProps } from "components/primitives";
-import type { ElementType, ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 export interface AccordionItemRecord {
   id: string;
   value: string;
   triggerLabel?: string;
   content: ReactNode;
-  icon?: ElementType;
+  icon?: ReactElement;
 }
 
 export interface Props extends AccordionProps {
@@ -51,19 +51,22 @@ const Accordion = ({ items, plusMinus, ...rest }: Props) => {
                 <Button w="full" borderBottomRadius={isOpen ? "unset" : "md"}>
                   {triggerLabel ?? value}
                   <Icon
-                    as={
-                      plusMinus
-                        ? isOpen
-                          ? MinusIcon
-                          : PlusIcon
-                        : icon ?? ChevronDownIcon
-                    }
                     transform={
                       isOpen && !plusMinus ? "rotate(-180deg)" : undefined
                     }
                     transformOrigin="center"
                     color="accent.fg"
-                  />
+                  >
+                    {plusMinus ? (
+                      isOpen ? (
+                        <MinusIcon />
+                      ) : (
+                        <PlusIcon />
+                      )
+                    ) : (
+                      (icon as ReactElement) ?? <ChevronDownIcon />
+                    )}
+                  </Icon>
                 </Button>
               </AccordionTrigger>
               <AccordionContent

--- a/src/components/client/core/Banner/Banner.tsx
+++ b/src/components/client/core/Banner/Banner.tsx
@@ -36,7 +36,9 @@ const Banner = ({ children, variant, closable, ...rest }: Props) => {
               _hover: "none",
             }}
           >
-            <Icon as={CloseIcon} color="bg.default" />
+            <Icon color="bg.default">
+              <CloseIcon />
+            </Icon>
           </Button>
         )}
       </panda.div>

--- a/src/components/client/core/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/client/core/Breadcrumb/Breadcrumb.stories.tsx
@@ -23,11 +23,9 @@ export const Pathname: Story = {
       rootLabel="🏝️"
       pathname="ethereum/collections/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
       separator={
-        <Icon
-          as={ChevronRightIcon}
-          color="accent.emphasized"
-          aria-label="separator-icon"
-        />
+        <Icon color="accent.emphasized" aria-label="separator-icon">
+          <ChevronRightIcon />
+        </Icon>
       }
     />
   ),
@@ -38,11 +36,9 @@ export const Breadcrumbs: Story = {
     <Breadcrumb
       breadcrumbs={BREADCRUMBS}
       separator={
-        <Icon
-          as={ChevronRightIcon}
-          color="accent.emphasized"
-          aria-label="separator-icon"
-        />
+        <Icon color="accent.emphasized" aria-label="separator-icon">
+          <ChevronRightIcon />
+        </Icon>
       }
     />
   ),

--- a/src/components/client/core/Carousel/Carousel.tsx
+++ b/src/components/client/core/Carousel/Carousel.tsx
@@ -46,7 +46,9 @@ const Carousel = ({ slides, size, ...rest }: Props) => {
         </CarouselSlideGroup>
         <CarouselControl className={classNames.control}>
           <CarouselPrevSlideTrigger className={classNames.trigger}>
-            <Icon as={FiChevronLeft} />
+            <Icon>
+              <FiChevronLeft />
+            </Icon>
           </CarouselPrevSlideTrigger>
           <CarouselIndicatorGroup className={classNames.indicatorGroup}>
             {slides.map((_, index) => (
@@ -59,7 +61,9 @@ const Carousel = ({ slides, size, ...rest }: Props) => {
             ))}
           </CarouselIndicatorGroup>
           <CarouselNextSlideTrigger className={classNames.trigger}>
-            <Icon as={FiChevronRight} />
+            <Icon>
+              <FiChevronRight />
+            </Icon>
           </CarouselNextSlideTrigger>
         </CarouselControl>
       </CarouselViewport>

--- a/src/components/client/core/Drawer/Drawer.tsx
+++ b/src/components/client/core/Drawer/Drawer.tsx
@@ -76,7 +76,9 @@ const Drawer = ({
                       _hover: "bg.subtle",
                     }}
                   >
-                    <Icon as={CloseIcon} color="fg.default" />
+                    <Icon color="fg.default">
+                      <CloseIcon />
+                    </Icon>
                   </Button>
                 </DrawerCloseTrigger>
               </DrawerContent>

--- a/src/components/client/core/Flyout/Flyout.tsx
+++ b/src/components/client/core/Flyout/Flyout.tsx
@@ -66,7 +66,9 @@ const Flyout = ({ trigger, title, children, ...rest }: Props) => {
               onClick={() => setIsOpen(false)}
               className={classNames.closeTrigger}
             >
-              <Icon as={CloseIcon} className={classNames.closeTriggerIcon} />
+              <Icon className={classNames.closeTriggerIcon}>
+                <CloseIcon />
+              </Icon>
             </FlyoutCloseTrigger>
           </FlyoutContent>
         </FlyoutPositioner>

--- a/src/components/client/core/Icon/Icon.stories.tsx
+++ b/src/components/client/core/Icon/Icon.stories.tsx
@@ -18,22 +18,34 @@ export const Variants: Story = {
   render: () => (
     <Flex gap={2}>
       <Flex h="fit-content" bgColor="purple.100" p={2} borderRadius="md">
-        <Icon as={FiBell} size="xs" color="purple.500" />
+        <Icon size="xs" color="purple.500">
+          <FiBell />
+        </Icon>
       </Flex>
       <Flex h="fit-content" bgColor="red.100" p={2} borderRadius="md">
-        <Icon as={FiHeart} size="sm" color="red.500" />
+        <Icon size="sm" color="red.500">
+          <FiHeart />
+        </Icon>
       </Flex>
       <Flex h="fit-content" bgColor="blue.100" p={2} borderRadius="md">
-        <Icon as={FiCheck} color="blue.500" />
+        <Icon color="blue.500">
+          <FiCheck />
+        </Icon>
       </Flex>
       <Flex h="fit-content" bgColor="gray.100" p={2} borderRadius="md">
-        <Icon as={FiExternalLink} size="lg" color="gray.500" />
+        <Icon size="lg" color="gray.500">
+          <FiExternalLink />
+        </Icon>
       </Flex>
       <Flex h="fit-content" bgColor="yellow.100" p={2} borderRadius="md">
-        <Icon as={FiAlertTriangle} size="xl" color="yellow.500" />
+        <Icon size="xl" color="yellow.500">
+          <FiAlertTriangle />
+        </Icon>
       </Flex>
       <Flex h="fit-content" bgColor="green.100" p={2} borderRadius="md">
-        <Icon as={FiBattery} size="2xl" color="green.500" />
+        <Icon size="2xl" color="green.500">
+          <FiBattery />
+        </Icon>
       </Flex>
     </Flex>
   ),

--- a/src/components/client/core/Icon/Icon.tsx
+++ b/src/components/client/core/Icon/Icon.tsx
@@ -1,22 +1,20 @@
+import { ark } from "@ark-ui/react";
+
 import { panda } from "generated/panda/jsx";
 import { icon } from "generated/panda/recipes";
 
+import type { HTMLPandaProps } from "generated/panda/jsx";
 import type { IconVariantProps } from "generated/panda/recipes";
-import type { HTMLPandaProps } from "generated/panda/types/jsx";
-import type { ElementType } from "react";
+import type { ReactElement } from "react";
 
-export interface Props extends HTMLPandaProps<"svg">, IconVariantProps {
-  as: ElementType;
+export interface Props extends IconVariantProps, HTMLPandaProps<"svg"> {
+  children: ReactElement;
 }
 
-/**
- * Core UI icon.
- */
-const Icon = ({ as, size, ...rest }: Props) => {
-  const className = icon({ size });
-  const Component = panda(as);
+const PandaIcon = panda(ark.svg, icon);
 
-  return <Component className={className} {...rest} />;
+const Icon = ({ ...props }: Props) => {
+  return <PandaIcon asChild {...props} />;
 };
 
 export default Icon;

--- a/src/components/client/core/Modal/Modal.tsx
+++ b/src/components/client/core/Modal/Modal.tsx
@@ -65,7 +65,9 @@ const Modal = ({ children, trigger, title, description, ...rest }: Props) => {
                       _hover: "bg.subtle",
                     }}
                   >
-                    <Icon as={CloseIcon} color="fg.default" />
+                    <Icon color="fg.default">
+                      <CloseIcon />
+                    </Icon>
                   </Button>
                 </ModalCloseTrigger>
               </ModalContent>

--- a/src/components/client/core/NumberInput/NumberInput.tsx
+++ b/src/components/client/core/NumberInput/NumberInput.tsx
@@ -88,11 +88,15 @@ const NumberInput = ({
         {stepper && (
           <NumberInputControl className={classNames.stepper}>
             <NumberInputDecrementTrigger className={classNames.stepperTrigger}>
-              <Icon as={FiMinus} className={classNames.stepperIcon} />
+              <Icon className={classNames.stepperIcon}>
+                <FiMinus />
+              </Icon>
             </NumberInputDecrementTrigger>
             <panda.div w="1px" h="75%" mx={0.5} my="auto" bgColor="gray.600" />
             <NumberInputIncrementTrigger className={classNames.stepperTrigger}>
-              <Icon as={FiPlus} className={classNames.stepperIcon} />
+              <Icon className={classNames.stepperIcon}>
+                <FiPlus />
+              </Icon>
             </NumberInputIncrementTrigger>
           </NumberInputControl>
         )}

--- a/src/components/client/core/Toast/Toast.tsx
+++ b/src/components/client/core/Toast/Toast.tsx
@@ -27,7 +27,9 @@ const Toast = ({ title, description, onClose, variant, ...rest }: Props) => {
           onClick={onClose}
           aria-label="Close Toast"
         >
-          <Icon as={FiX} h={4} w={4} />
+          <Icon h={4} w={4}>
+            <FiX />
+          </Icon>
         </panda.button>
       )}
 

--- a/src/components/client/utility/Collapse/Collapse.tsx
+++ b/src/components/client/utility/Collapse/Collapse.tsx
@@ -7,11 +7,11 @@ import Icon from "components/client/core/Icon/Icon";
 import { Flex } from "generated/panda/jsx";
 
 import type { FlexProps } from "generated/panda/jsx";
-import type { ElementType, ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 export interface Props extends FlexProps {
   label?: string;
-  icon?: ElementType;
+  icon?: ReactElement;
   open?: boolean;
   children?: ReactNode;
   collapseDirection?: "horizontal" | "vertical";
@@ -31,7 +31,7 @@ const Collapse = ({
   const [isOpen, setIsOpen] = useState(open ?? false);
 
   const isHorizontal = collapseDirection == "horizontal";
-  const defaultIcon = isHorizontal ? FiChevronRight : FiChevronDown;
+  const defaultIcon = isHorizontal ? <FiChevronRight /> : <FiChevronDown />;
 
   return (
     <Flex direction={isHorizontal ? "row-reverse" : "column"} gap={2} {...rest}>
@@ -44,10 +44,9 @@ const Collapse = ({
         onClick={() => setIsOpen(!isOpen)}
       >
         {label}
-        <Icon
-          transform={isOpen && !icon ? "rotate(-180deg)" : undefined}
-          as={icon ?? defaultIcon}
-        />
+        <Icon transform={isOpen && !icon ? "rotate(-180deg)" : undefined}>
+          {icon ?? defaultIcon}
+        </Icon>
       </Button>
       <AnimatePresence initial={isOpen}>
         {isOpen && (


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/dI6YmJMw/209-automatically-apply-svg-props-to-icon-component-to-avoid-duplication

Refactored `Icon` component to remove need for `as` prop usage. This should automatically apply SVG props to component to avoid duplication downstream. This should also allow for more control over the styling.

## Test Steps

1) Verify component structure is sound.
2) Verify that stories, and downstream app usage renders appropriately (specifically test components that use `Icon` internally like `Modal`)
