### PR TITLE
Add Default `height` and `width` to Container for NextJS Enhanced `Image` Component

### DIFF
--- a/.changeset/rich-falcons-hug.md
+++ b/.changeset/rich-falcons-hug.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Add default height and width to container props for nextjs enhanced `Image` component

--- a/src/components/next/Image/Image.tsx
+++ b/src/components/next/Image/Image.tsx
@@ -21,12 +21,17 @@ if ("default" in ResolvedImage) {
 /**
  * Next.js-enhanced image.
  */
-const Image = ({ containerProps, style, fill, ...rest }: Props) => (
+const Image = ({
+  containerProps = { w: "100%", h: "100%" },
+  style,
+  fill,
+  ...rest
+}: Props) => (
   <AspectRatio
     pos="relative"
     overflow="hidden"
-    w={style ? undefined : fill ? "100%" : containerProps!.w}
-    h={style ? undefined : fill ? "100%" : containerProps!.h}
+    w={style ? undefined : fill ? "100%" : containerProps.w}
+    h={style ? undefined : fill ? "100%" : containerProps.h}
     style={style}
     {...containerProps}
   >


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/a7iPj0Rw/207-nextjs-image-set-default-containerprops-w-and-h-open-to-discussion

Added default `height` and `width` to container for NextJS Enhanced `Image` component.

## Test Steps

1) Verify component structure is sound.
