### PR TITLE
Add `Tooltip` color prop for content and arrow slots

### DIFF
--- a/.changeset/polite-colts-obey.md
+++ b/.changeset/polite-colts-obey.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Added `Tooltip` color prop for content and arrow slots

--- a/src/components/client/core/Tooltip/Tooltip.recipe.ts
+++ b/src/components/client/core/Tooltip/Tooltip.recipe.ts
@@ -22,12 +22,13 @@ export const tooltipRecipe = defineSlotRecipe({
     },
     arrow: {
       "--arrow-size": "var(--sizes-3)",
-      "--arrow-background": "var(--colors-bg-default)",
+      rotate: "45deg",
     },
     arrowTip: {
       borderTopWidth: "1px",
       borderColor: "border.default",
       borderLeftWidth: "1px",
+      rotate: "-45deg",
     },
   },
 });

--- a/src/components/client/core/Tooltip/Tooltip.tsx
+++ b/src/components/client/core/Tooltip/Tooltip.tsx
@@ -17,6 +17,7 @@ import type { ReactNode } from "react";
 export interface Props extends TooltipProps {
   trigger: ReactNode;
   content: ReactNode;
+  bgColor?: string;
 }
 
 /**
@@ -27,6 +28,7 @@ const Tooltip = ({
   content,
   openDelay = 0,
   closeDelay = 0,
+  bgColor = "bg.default",
   ...rest
 }: Props) => {
   const classNames = tooltip();
@@ -43,11 +45,18 @@ const Tooltip = ({
           <Portal>
             <TooltipPositioner className={classNames.positioner}>
               {isOpen && (
-                <TooltipArrow className={classNames.arrow}>
-                  <TooltipArrowTip className={classNames.arrowTip} />
+                <TooltipArrow
+                  bgColor={bgColor}
+                  rotate="45deg"
+                  className={classNames.arrow}
+                >
+                  <TooltipArrowTip
+                    rotate="-45deg"
+                    className={classNames.arrowTip}
+                  />
                 </TooltipArrow>
               )}
-              <TooltipContent className={classNames.content}>
+              <TooltipContent bgColor={bgColor} className={classNames.content}>
                 {content}
               </TooltipContent>
             </TooltipPositioner>


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/w8KpyFoS/206-allow-customizing-tooltip-content-container-eg-background-color

Added `bgColor` prop type.

## Test Steps

1. Test bgColor with semantic colors (accent.default) and other base panda colors (red, orange.500, etc).
