### PR TITLE
Fix: Update Primitive Component Types

### DIFF
--- a/.changeset/good-laws-confess.md
+++ b/.changeset/good-laws-confess.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": minor
+---
+
+Update all primitive component types using pattern `ComponentProps<typeof PRIMITIVE>`

--- a/.changeset/tender-taxis-live.md
+++ b/.changeset/tender-taxis-live.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": minor
+---
+
+Remove unnecessary `triggerProps` from `Tooltip` props

--- a/.changeset/twelve-walls-think.md
+++ b/.changeset/twelve-walls-think.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": minor
+---
+
+Change `content` prop to `tooltipContent` to avoid prop collision

--- a/.changeset/violet-carrots-press.md
+++ b/.changeset/violet-carrots-press.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Update primitive component typings to include panda props

--- a/.changeset/violet-carrots-press.md
+++ b/.changeset/violet-carrots-press.md
@@ -1,5 +1,0 @@
----
-"@animareflection/ui": patch
----
-
-Update primitive component typings to include panda props

--- a/examples/next/src/components/TooltipDemo.tsx
+++ b/examples/next/src/components/TooltipDemo.tsx
@@ -10,7 +10,7 @@ const TooltipDemo = () => {
           placement: "top",
         }}
         trigger={<Text>Open Tooltip</Text>}
-        content="Tooltip Title"
+        tooltipContent="Tooltip Title"
         triggerProps={{
           bgColor: "brand.primary.500",
           p: 3,

--- a/examples/next/src/components/TooltipDemo.tsx
+++ b/examples/next/src/components/TooltipDemo.tsx
@@ -9,15 +9,18 @@ const TooltipDemo = () => {
         positioning={{
           placement: "top",
         }}
-        trigger={<Text>Open Tooltip</Text>}
+        trigger={
+          <Text
+            bgColor="brand.primary.500"
+            p={3}
+            borderRadius="md"
+            color="accent.fg"
+            fontWeight="bold"
+          >
+            Open Tooltip
+          </Text>
+        }
         tooltipContent="Tooltip Title"
-        triggerProps={{
-          bgColor: "brand.primary.500",
-          p: 3,
-          borderRadius: "md",
-          color: "accent.fg",
-          fontWeight: "bold",
-        }}
       />
     </Wrapper>
   );

--- a/examples/vite-react/src/components/TooltipDemo.tsx
+++ b/examples/vite-react/src/components/TooltipDemo.tsx
@@ -10,7 +10,7 @@ const TooltipDemo = () => {
           placement: "top",
         }}
         trigger={<Text>Open Tooltip</Text>}
-        content="Tooltip Title"
+        tooltipContent="Tooltip Title"
         triggerProps={{
           bgColor: "brand.primary.500",
           p: 3,

--- a/examples/vite-react/src/components/TooltipDemo.tsx
+++ b/examples/vite-react/src/components/TooltipDemo.tsx
@@ -9,15 +9,18 @@ const TooltipDemo = () => {
         positioning={{
           placement: "top",
         }}
-        trigger={<Text>Open Tooltip</Text>}
+        trigger={
+          <Text
+            bgColor="brand.primary.500"
+            p={3}
+            borderRadius="md"
+            color="accent.fg"
+            fontWeight="bold"
+          >
+            Open Tooltip
+          </Text>
+        }
         tooltipContent="Tooltip Title"
-        triggerProps={{
-          bgColor: "brand.primary.500",
-          p: 3,
-          borderRadius: "md",
-          color: "accent.fg",
-          fontWeight: "bold",
-        }}
       />
     </Wrapper>
   );

--- a/src/components/core/Tooltip/Tooltip.stories.tsx
+++ b/src/components/core/Tooltip/Tooltip.stories.tsx
@@ -37,7 +37,7 @@ const TooltipTemplate = ({ placement }: { placement: Placement }) => (
         {placement}
       </Text>
     }
-    content="Tooltip Title"
+    tooltipContent="Tooltip Title"
   />
 );
 
@@ -45,7 +45,7 @@ export const Default: Story = {
   render: () => (
     <Tooltip
       trigger={<Text fontWeight="bold">Tooltip</Text>}
-      content="Tooltip Title"
+      tooltipContent="Tooltip Title"
     />
   ),
 };
@@ -75,7 +75,7 @@ export const Variants: Story = {
   render: () => (
     <Tooltip
       trigger={<Text fontWeight="bold">Rounded</Text>}
-      content="Tooltip Title"
+      tooltipContent="Tooltip Title"
       variant="rounded"
     />
   ),

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -11,10 +11,7 @@ import {
 import { tooltip } from "generated/panda/recipes";
 import { useIsMounted } from "lib/hooks";
 
-import type {
-  PrimitiveTooltipProps,
-  PrimitiveTooltipTriggerProps,
-} from "components/primitives";
+import type { PrimitiveTooltipProps } from "components/primitives";
 import type { TooltipVariantProps } from "generated/panda/recipes";
 import type { JsxStyleProps } from "generated/panda/types";
 import type { ReactNode } from "react";
@@ -23,7 +20,6 @@ export interface Props extends PrimitiveTooltipProps, TooltipVariantProps {
   trigger?: ReactNode;
   tooltipContent: ReactNode;
   bgColor?: JsxStyleProps["bgColor"];
-  triggerProps?: PrimitiveTooltipTriggerProps;
   arrow?: boolean;
 }
 
@@ -37,7 +33,6 @@ const Tooltip = ({
   closeDelay = 0,
   bgColor = "bg.default",
   variant,
-  triggerProps,
   arrow = true,
   ...rest
 }: Props) => {
@@ -52,11 +47,7 @@ const Tooltip = ({
       {({ isOpen }) => (
         <>
           {trigger && (
-            <PrimitiveTooltipTrigger
-              asChild
-              className={classNames.trigger}
-              {...triggerProps}
-            >
+            <PrimitiveTooltipTrigger asChild className={classNames.trigger}>
               {trigger}
             </PrimitiveTooltipTrigger>
           )}

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -21,7 +21,7 @@ import type { ReactNode } from "react";
 
 export interface Props extends PrimitiveTooltipProps, TooltipVariantProps {
   trigger?: ReactNode;
-  content: ReactNode;
+  tooltipContent: ReactNode;
   bgColor?: JsxStyleProps["bgColor"];
   triggerProps?: PrimitiveTooltipTriggerProps;
   arrow?: boolean;
@@ -32,7 +32,7 @@ export interface Props extends PrimitiveTooltipProps, TooltipVariantProps {
  */
 const Tooltip = ({
   trigger,
-  content,
+  tooltipContent,
   openDelay = 0,
   closeDelay = 0,
   bgColor = "bg.default",
@@ -79,7 +79,7 @@ const Tooltip = ({
                     bgColor={bgColor}
                     className={classNames.content}
                   >
-                    {content}
+                    {tooltipContent}
                   </PrimitiveTooltipContent>
                 </>
               )}

--- a/src/components/primitives/Accordion/Accordion.tsx
+++ b/src/components/primitives/Accordion/Accordion.tsx
@@ -7,28 +7,29 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  AccordionProps,
-  AccordionItemProps,
-  AccordionTriggerProps,
-  AccordionContentProps,
-} from "@ark-ui/react";
 import type { PandaComponent } from "generated/panda/types/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI accordion primitives.
  */
-export type PrimitiveAccordionProps = AccordionProps;
+export type PrimitiveAccordionProps = ComponentProps<typeof PrimitiveAccordion>;
 const PrimitiveAccordion: PandaComponent<typeof Accordion> = panda(Accordion);
 
-export type PrimitiveAccordionItemProps = AccordionItemProps;
+export type PrimitiveAccordionItemProps = ComponentProps<
+  typeof PrimitiveAccordionItem
+>;
 export const PrimitiveAccordionItem: PandaComponent<typeof AccordionItem> =
   panda(AccordionItem);
 
-export type PrimitiveAccordionTriggerProps = AccordionTriggerProps;
+export type PrimitiveAccordionTriggerProps = ComponentProps<
+  typeof PrimitiveAccordionTrigger
+>;
 export const PrimitiveAccordionTrigger = panda(AccordionTrigger);
 
-export type PrimitiveAccordionContentProps = AccordionContentProps;
+export type PrimitiveAccordionContentProps = ComponentProps<
+  typeof PrimitiveAccordionContent
+>;
 export const PrimitiveAccordionContent = panda(AccordionContent);
 
 export default PrimitiveAccordion;

--- a/src/components/primitives/Avatar/Avatar.tsx
+++ b/src/components/primitives/Avatar/Avatar.tsx
@@ -2,23 +2,23 @@ import { Avatar, AvatarFallback, AvatarImage } from "@ark-ui/react";
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  AvatarProps,
-  AvatarFallbackProps,
-  AvatarImageProps,
-} from "@ark-ui/react";
 import type { PandaComponent } from "generated/panda/types/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI avatar primitives.
  */
-export type PrimitiveAvatarProps = AvatarProps;
+export type PrimitiveAvatarProps = ComponentProps<typeof PrimitiveAvatar>;
 const PrimitiveAvatar: PandaComponent<typeof Avatar> = panda(Avatar);
 
-export type PrimitiveAvatarFallbackProps = AvatarFallbackProps;
+export type PrimitiveAvatarFallbackProps = ComponentProps<
+  typeof PrimitiveAvatarFallback
+>;
 export const PrimitiveAvatarFallback = panda(AvatarFallback);
 
-export type PrimitiveAvatarImageProps = AvatarImageProps;
+export type PrimitiveAvatarImageProps = ComponentProps<
+  typeof PrimitiveAvatarImage
+>;
 export const PrimitiveAvatarImage = panda(AvatarImage);
 
 export default PrimitiveAvatar;

--- a/src/components/primitives/Carousel/Carousel.tsx
+++ b/src/components/primitives/Carousel/Carousel.tsx
@@ -12,56 +12,60 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  CarouselProps,
-  CarouselControlProps,
-  CarouselNextSlideTriggerProps,
-  CarouselPrevSlideTriggerProps,
-  CarouselSlideProps,
-  CarouselSlideGroupProps,
-  CarouselViewportProps,
-  CarouselIndicatorProps,
-  CarouselIndicatorGroupProps,
-} from "@ark-ui/react";
 import type { PandaComponent } from "generated/panda/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI carousel primitives.
  */
-export type PrimitiveCarouselProps = CarouselProps;
+export type PrimitiveCarouselProps = ComponentProps<typeof PrimitiveCarousel>;
 const PrimitiveCarousel: PandaComponent<typeof Carousel> = panda(Carousel);
 
-export type PrimitiveCarouselControlProps = CarouselControlProps;
+export type PrimitiveCarouselControlProps = ComponentProps<
+  typeof PrimitiveCarouselControl
+>;
 export const PrimitiveCarouselControl = panda(CarouselControl);
 
-export type PrimitiveCarouselNextSlideTriggerProps =
-  CarouselNextSlideTriggerProps;
+export type PrimitiveCarouselNextSlideTriggerProps = ComponentProps<
+  typeof PrimitiveCarouselNextSlideTrigger
+>;
 export const PrimitiveCarouselNextSlideTrigger = panda(
   CarouselNextSlideTrigger,
 );
 
-export type PrimitiveCarouselPrevSlideTriggerProps =
-  CarouselPrevSlideTriggerProps;
+export type PrimitiveCarouselPrevSlideTriggerProps = ComponentProps<
+  typeof PrimitiveCarouselPrevSlideTrigger
+>;
 export const PrimitiveCarouselPrevSlideTrigger = panda(
   CarouselPrevSlideTrigger,
 );
 
-export type PrimitiveCarouselSlideProps = CarouselSlideProps;
+export type PrimitiveCarouselSlideProps = ComponentProps<
+  typeof PrimitiveCarouselSlide
+>;
 export const PrimitiveCarouselSlide: PandaComponent<typeof CarouselSlide> =
   panda(CarouselSlide);
 
-export type PrimitiveCarouselSlideGroupProps = CarouselSlideGroupProps;
+export type PrimitiveCarouselSlideGroupProps = ComponentProps<
+  typeof PrimitiveCarouselSlideGroup
+>;
 export const PrimitiveCarouselSlideGroup = panda(CarouselSlideGroup);
 
-export type PrimitiveCarouselViewportProps = CarouselViewportProps;
+export type PrimitiveCarouselViewportProps = ComponentProps<
+  typeof PrimitiveCarouselViewport
+>;
 export const PrimitiveCarouselViewport = panda(CarouselViewport);
 
-export type PrimitiveCarouselIndicatorProps = CarouselIndicatorProps;
+export type PrimitiveCarouselIndicatorProps = ComponentProps<
+  typeof PrimitiveCarouselIndicator
+>;
 export const PrimitiveCarouselIndicator: PandaComponent<
   typeof CarouselIndicator
 > = panda(CarouselIndicator);
 
-export type PrimitiveCarouselIndicatorGroupProps = CarouselIndicatorGroupProps;
+export type PrimitiveCarouselIndicatorGroupProps = ComponentProps<
+  typeof PrimitiveCarouselIndicatorGroup
+>;
 export const PrimitiveCarouselIndicatorGroup = panda(CarouselIndicatorGroup);
 
 export default PrimitiveCarousel;

--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -2,22 +2,22 @@ import { Checkbox, CheckboxControl, CheckboxLabel } from "@ark-ui/react";
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  CheckboxProps,
-  CheckboxControlProps,
-  CheckboxLabelProps,
-} from "@ark-ui/react";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI checkbox primitives.
  */
-export type PrimitiveCheckboxProps = CheckboxProps;
+export type PrimitiveCheckboxProps = ComponentProps<typeof PrimitiveCheckbox>;
 const PrimitiveCheckbox = panda(Checkbox);
 
-export type PrimitiveCheckboxControlProps = CheckboxControlProps;
+export type PrimitiveCheckboxControlProps = ComponentProps<
+  typeof PrimitiveCheckboxControl
+>;
 export const PrimitiveCheckboxControl = panda(CheckboxControl);
 
-export type PrimitiveCheckboxLabelProps = CheckboxLabelProps;
+export type PrimitiveCheckboxLabelProps = ComponentProps<
+  typeof PrimitiveCheckboxLabel
+>;
 export const PrimitiveCheckboxLabel = panda(CheckboxLabel);
 
 export default PrimitiveCheckbox;

--- a/src/components/primitives/Drawer/Drawer.tsx
+++ b/src/components/primitives/Drawer/Drawer.tsx
@@ -11,44 +11,47 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  DialogBackdropProps,
-  DialogCloseTriggerProps,
-  DialogContainerProps,
-  DialogContentProps,
-  DialogDescriptionProps,
-  DialogProps,
-  DialogTitleProps,
-  DialogTriggerProps,
-} from "@ark-ui/react";
-import type { HTMLPandaProps } from "generated/panda/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI drawer primitives.
  */
-export type PrimitiveDrawerProps = DialogProps;
+export type PrimitiveDrawerProps = ComponentProps<typeof PrimitiveDrawer>;
 const PrimitiveDrawer = panda(Dialog);
 
-export type PrimitiveDrawerTriggerProps = DialogTriggerProps;
+export type PrimitiveDrawerTriggerProps = ComponentProps<
+  typeof PrimitiveDrawerTrigger
+>;
 export const PrimitiveDrawerTrigger = panda(DialogTrigger);
 
-export type PrimitiveDrawerBackdropProps = DialogBackdropProps;
+export type PrimitiveDrawerBackdropProps = ComponentProps<
+  typeof PrimitiveDrawerBackdrop
+>;
 export const PrimitiveDrawerBackdrop = panda(DialogBackdrop);
 
-export type PrimitiveDrawerContainerProps = DialogContainerProps;
+export type PrimitiveDrawerContainerProps = ComponentProps<
+  typeof PrimitiveDrawerContainer
+>;
 export const PrimitiveDrawerContainer = panda(DialogContainer);
 
-export type PrimitiveDrawerContentProps = DialogContentProps &
-  HTMLPandaProps<"div">;
+export type PrimitiveDrawerContentProps = ComponentProps<
+  typeof PrimitiveDrawerContent
+>;
 export const PrimitiveDrawerContent = panda(DialogContent);
 
-export type PrimitiveDrawerCloseTriggerProps = DialogCloseTriggerProps;
+export type PrimitiveDrawerCloseTriggerProps = ComponentProps<
+  typeof PrimitiveDrawerCloseTrigger
+>;
 export const PrimitiveDrawerCloseTrigger = panda(DialogCloseTrigger);
 
-export type PrimitiveDrawerTitleProps = DialogTitleProps;
+export type PrimitiveDrawerTitleProps = ComponentProps<
+  typeof PrimitiveDrawerTitle
+>;
 export const PrimitiveDrawerTitle = panda(DialogTitle);
 
-export type PrimitiveDrawerDescriptionProps = DialogDescriptionProps;
+export type PrimitiveDrawerDescriptionProps = ComponentProps<
+  typeof PrimitiveDrawerDescription
+>;
 export const PrimitiveDrawerDescription = panda(DialogDescription);
 
 export default PrimitiveDrawer;

--- a/src/components/primitives/Flyout/Flyout.tsx
+++ b/src/components/primitives/Flyout/Flyout.tsx
@@ -12,46 +12,52 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  PopoverProps,
-  PopoverArrowProps,
-  PopoverArrowTipProps,
-  PopoverCloseTriggerProps,
-  PopoverContentProps,
-  PopoverDescriptionProps,
-  PopoverPositionerProps,
-  PopoverTitleProps,
-  PopoverTriggerProps,
-} from "@ark-ui/react";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI flyout primitives.
  */
-export type PrimitiveFlyoutProps = PopoverProps;
+export type PrimitiveFlyoutProps = ComponentProps<typeof PrimitiveFlyout>;
 const PrimitiveFlyout = panda(Popover);
 
-export type PrimitiveFlyoutArrowProps = PopoverArrowProps;
+export type PrimitiveFlyoutArrowProps = ComponentProps<
+  typeof PrimitiveFlyoutArrow
+>;
 export const PrimitiveFlyoutArrow = panda(PopoverArrow);
 
-export type PrimitiveFlyoutArrowTipProps = PopoverArrowTipProps;
+export type PrimitiveFlyoutArrowTipProps = ComponentProps<
+  typeof PrimitiveFlyoutArrowTip
+>;
 export const PrimitiveFlyoutArrowTip = panda(PopoverArrowTip);
 
-export type PrimitiveFlyoutCloseTriggerProps = PopoverCloseTriggerProps;
+export type PrimitiveFlyoutCloseTriggerProps = ComponentProps<
+  typeof PrimitiveFlyoutCloseTrigger
+>;
 export const PrimitiveFlyoutCloseTrigger = panda(PopoverCloseTrigger);
 
-export type PrimitiveFlyoutContentProps = PopoverContentProps;
+export type PrimitiveFlyoutContentProps = ComponentProps<
+  typeof PrimitiveFlyoutContent
+>;
 export const PrimitiveFlyoutContent = panda(PopoverContent);
 
-export type PrimitiveFlyoutDescriptionProps = PopoverDescriptionProps;
+export type PrimitiveFlyoutDescriptionProps = ComponentProps<
+  typeof PrimitiveFlyoutDescription
+>;
 export const PrimitiveFlyoutDescription = panda(PopoverDescription);
 
-export type PrimitiveFlyoutPositionerProps = PopoverPositionerProps;
+export type PrimitiveFlyoutPositionerProps = ComponentProps<
+  typeof PrimitiveFlyoutPositioner
+>;
 export const PrimitiveFlyoutPositioner = panda(PopoverPositioner);
 
-export type PrimitiveFlyoutTitleProps = PopoverTitleProps;
+export type PrimitiveFlyoutTitleProps = ComponentProps<
+  typeof PrimitiveFlyoutTitle
+>;
 export const PrimitiveFlyoutTitle = panda(PopoverTitle);
 
-export type PrimitiveFlyoutTriggerProps = PopoverTriggerProps;
+export type PrimitiveFlyoutTriggerProps = ComponentProps<
+  typeof PrimitiveFlyoutTrigger
+>;
 export const PrimitiveFlyoutTrigger = panda(PopoverTrigger);
 
 export default PrimitiveFlyout;

--- a/src/components/primitives/Menu/Menu.tsx
+++ b/src/components/primitives/Menu/Menu.tsx
@@ -16,73 +16,76 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  MenuProps,
-  MenuArrowProps,
-  MenuArrowTipProps,
-  MenuContentProps,
-  MenuContextTriggerProps,
-  MenuItemProps,
-  MenuItemGroupProps,
-  MenuItemGroupLabelProps,
-  MenuOptionItemProps,
-  MenuPositionerProps,
-  MenuSeparatorProps,
-  MenuTriggerProps,
-  MenuTriggerItemProps,
-} from "@ark-ui/react";
 import type { PandaComponent } from "generated/panda/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI menu primitives.
  */
-export type PrimitiveMenuProps = MenuProps;
-
+export type PrimitiveMenuProps = ComponentProps<typeof PrimitiveMenu>;
 // TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
 const PrimitiveMenu: PandaComponent<typeof Menu> = panda(Menu);
 
-export type PrimitiveMenuArrowProps = MenuArrowProps;
+export type PrimitiveMenuArrowProps = ComponentProps<typeof PrimitiveMenuArrow>;
 export const PrimitiveMenuArrow = panda(MenuArrow);
 
-export type PrimitiveMenuArrowTipProps = MenuArrowTipProps;
+export type PrimitiveMenuArrowTipProps = ComponentProps<
+  typeof PrimitiveMenuArrowTip
+>;
 export const PrimitiveMenuArrowTip = panda(MenuArrowTip);
 
-export type PrimitiveMenuContentProps = MenuContentProps;
+export type PrimitiveMenuContentProps = ComponentProps<
+  typeof PrimitiveMenuContent
+>;
 export const PrimitiveMenuContent = panda(MenuContent);
 
-export type PrimitiveMenuContextTriggerProps = MenuContextTriggerProps;
+export type PrimitiveMenuContextTriggerProps = ComponentProps<
+  typeof PrimitiveMenuContextTrigger
+>;
 export const PrimitiveMenuContextTrigger = panda(MenuContextTrigger);
 
-export type PrimitiveMenuItemProps = MenuItemProps;
-
+export type PrimitiveMenuItemProps = ComponentProps<typeof PrimitiveMenuItem>;
 // TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
 export const PrimitiveMenuItem: PandaComponent<typeof MenuItem> =
   panda(MenuItem);
 
-export type PrimitiveMenuItemGroupProps = MenuItemGroupProps;
-
+export type PrimitiveMenuItemGroupProps = ComponentProps<
+  typeof PrimitiveMenuItemGroup
+>;
 // TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
 export const PrimitiveMenuItemGroup: PandaComponent<typeof MenuItemGroup> =
   panda(MenuItemGroup);
 
-export type PrimitiveMenuItemGroupLabelProps = MenuItemGroupLabelProps;
+export type PrimitiveMenuItemGroupLabelProps = ComponentProps<
+  typeof PrimitiveMenuItemGroupLabel
+>;
 export const PrimitiveMenuItemGroupLabel = panda(MenuItemGroupLabel);
 
-export type PrimitiveMenuOptionItemProps = MenuOptionItemProps;
+export type PrimitiveMenuOptionItemProps = ComponentProps<
+  typeof PrimitiveMenuOptionItem
+>;
 // TODO remove explicit type annotation, required due to `pnpm` bug (and therefore Yarn with `pnpm` linker); https://github.com/microsoft/TypeScript/issues/47663
 export const PrimitiveMenuOptionItem: PandaComponent<typeof MenuOptionItem> =
   panda(MenuOptionItem);
 
-export type PrimitiveMenuPositionerProps = MenuPositionerProps;
+export type PrimitiveMenuPositionerProps = ComponentProps<
+  typeof PrimitiveMenuPositioner
+>;
 export const PrimitiveMenuPositioner = panda(MenuPositioner);
 
-export type PrimitiveMenuSeparatorProps = MenuSeparatorProps;
+export type PrimitiveMenuSeparatorProps = ComponentProps<
+  typeof PrimitiveMenuSeparator
+>;
 export const PrimitiveMenuSeparator = panda(MenuSeparator);
 
-export type PrimitiveMenuTriggerProps = MenuTriggerProps;
+export type PrimitiveMenuTriggerProps = ComponentProps<
+  typeof PrimitiveMenuTrigger
+>;
 export const PrimitiveMenuTrigger = panda(MenuTrigger);
 
-export type PrimitiveMenuTriggerItemProps = MenuTriggerItemProps;
+export type PrimitiveMenuTriggerItemProps = ComponentProps<
+  typeof PrimitiveMenuTriggerItem
+>;
 export const PrimitiveMenuTriggerItem = panda(MenuTriggerItem);
 
 export default PrimitiveMenu;

--- a/src/components/primitives/Modal/Modal.tsx
+++ b/src/components/primitives/Modal/Modal.tsx
@@ -11,42 +11,47 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  DialogBackdropProps,
-  DialogCloseTriggerProps,
-  DialogContainerProps,
-  DialogContentProps,
-  DialogDescriptionProps,
-  DialogProps,
-  DialogTitleProps,
-  DialogTriggerProps,
-} from "@ark-ui/react";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI modal primitives.
  */
-export type PrimitiveModalProps = DialogProps;
+export type PrimitiveModalProps = ComponentProps<typeof PrimitiveModal>;
 const PrimitiveModal = panda(Dialog);
 
-export type PrimitiveModalTriggerProps = DialogTriggerProps;
+export type PrimitiveModalTriggerProps = ComponentProps<
+  typeof PrimitiveModalTrigger
+>;
 export const PrimitiveModalTrigger = panda(DialogTrigger);
 
-export type PrimitiveModalBackdropProps = DialogBackdropProps;
+export type PrimitiveModalBackdropProps = ComponentProps<
+  typeof PrimitiveModalBackdrop
+>;
 export const PrimitiveModalBackdrop = panda(DialogBackdrop);
 
-export type PrimitiveModalContainerProps = DialogContainerProps;
+export type PrimitiveModalContainerProps = ComponentProps<
+  typeof PrimitiveModalContainer
+>;
 export const PrimitiveModalContainer = panda(DialogContainer);
 
-export type PrimitiveModalContentProps = DialogContentProps;
+export type PrimitiveModalContentProps = ComponentProps<
+  typeof PrimitiveModalContent
+>;
 export const PrimitiveModalContent = panda(DialogContent);
 
-export type PrimitiveModalCloseTriggerProps = DialogCloseTriggerProps;
+export type PrimitiveModalCloseTriggerProps = ComponentProps<
+  typeof PrimitiveModalCloseTrigger
+>;
 export const PrimitiveModalCloseTrigger = panda(DialogCloseTrigger);
 
-export type PrimitiveModalTitleProps = DialogTitleProps;
+export type PrimitiveModalTitleProps = ComponentProps<
+  typeof PrimitiveModalTitle
+>;
 export const PrimitiveModalTitle = panda(DialogTitle);
 
-export type PrimitiveModalDescriptionProps = DialogDescriptionProps;
+export type PrimitiveModalDescriptionProps = ComponentProps<
+  typeof PrimitiveModalDescription
+>;
 export const PrimitiveModalDescription = panda(DialogDescription);
 
 export default PrimitiveModal;

--- a/src/components/primitives/NumberInput/NumberInput.tsx
+++ b/src/components/primitives/NumberInput/NumberInput.tsx
@@ -10,49 +10,50 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  NumberInputControlProps,
-  NumberInputDecrementTriggerProps,
-  NumberInputIncrementTriggerProps,
-  NumberInputInputProps,
-  NumberInputLabelProps,
-  NumberInputProps,
-  NumberInputScrubberProps,
-} from "@ark-ui/react";
-import type { HTMLPandaProps } from "generated/panda/jsx";
 import type { PandaComponent } from "generated/panda/types/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI number input primitives.
  */
-export type PrimitiveNumberInputProps = NumberInputProps &
-  HTMLPandaProps<"div">;
+export type PrimitiveNumberInputProps = ComponentProps<
+  typeof PrimitiveNumberInput
+>;
 const PrimitiveNumberInput: PandaComponent<typeof NumberInput> =
   panda(NumberInput);
 
-export type PrimitiveNumberInputControlProps = NumberInputControlProps;
+export type PrimitiveNumberInputControlProps = ComponentProps<
+  typeof PrimitiveNumberInputControl
+>;
 export const PrimitiveNumberInputControl = panda(NumberInputControl);
 
-export type PrimitiveNumberInputDecrementTriggerProps =
-  NumberInputDecrementTriggerProps;
+export type PrimitiveNumberInputDecrementTriggerProps = ComponentProps<
+  typeof PrimitiveNumberInputDecrementTrigger
+>;
 export const PrimitiveNumberInputDecrementTrigger = panda(
   NumberInputDecrementTrigger,
 );
 
-export type PrimitiveNumberInputIncrementTriggerProps =
-  NumberInputIncrementTriggerProps;
+export type PrimitiveNumberInputIncrementTriggerProps = ComponentProps<
+  typeof PrimitiveNumberInputIncrementTrigger
+>;
 export const PrimitiveNumberInputIncrementTrigger = panda(
   NumberInputIncrementTrigger,
 );
 
-export type PrimitiveNumberInputInputProps = NumberInputInputProps &
-  HTMLPandaProps<"input">;
+export type PrimitiveNumberInputInputProps = ComponentProps<
+  typeof PrimitiveNumberInputInput
+>;
 export const PrimitiveNumberInputInput = panda(NumberInputInput);
 
-export type PrimitiveNumberInputLabelProps = NumberInputLabelProps;
+export type PrimitiveNumberInputLabelProps = ComponentProps<
+  typeof PrimitiveNumberInputLabel
+>;
 export const PrimitiveNumberInputLabel = panda(NumberInputLabel);
 
-export type PrimitiveNumberInputScrubberProps = NumberInputScrubberProps;
+export type PrimitiveNumberInputScrubberProps = ComponentProps<
+  typeof PrimitiveNumberInputScrubber
+>;
 export const PrimitiveNumberInputScrubber = panda(NumberInputScrubber);
 
 export default PrimitiveNumberInput;

--- a/src/components/primitives/RadioGroup/RadioGroup.tsx
+++ b/src/components/primitives/RadioGroup/RadioGroup.tsx
@@ -2,28 +2,29 @@ import { Radio, RadioControl, RadioGroup, RadioLabel } from "@ark-ui/react";
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  RadioProps,
-  RadioControlProps,
-  RadioGroupProps,
-  RadioLabelProps,
-} from "@ark-ui/react";
 import type { PandaComponent } from "generated/panda/types/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI radio group primitives.
  */
-export type PrimitiveRadioGroupProps = RadioGroupProps;
+export type PrimitiveRadioGroupProps = ComponentProps<
+  typeof PrimitiveRadioGroup
+>;
 const PrimitiveRadioGroup: PandaComponent<typeof RadioGroup> =
   panda(RadioGroup);
 
-export type PrimitiveRadioControlProps = RadioControlProps;
+export type PrimitiveRadioControlProps = ComponentProps<
+  typeof PrimitiveRadioControl
+>;
 export const PrimitiveRadioControl = panda(RadioControl);
 
-export type PrimitiveRadioLabelProps = RadioLabelProps;
+export type PrimitiveRadioLabelProps = ComponentProps<
+  typeof PrimitiveRadioLabel
+>;
 export const PrimitiveRadioLabel = panda(RadioLabel);
 
-export type PrimitiveRadioProps = RadioProps;
-export const PrimitiveRadio = panda(Radio);
+export type PrimitiveRadioProps = ComponentProps<typeof PrimitiveRadio>;
+export const PrimitiveRadio: PandaComponent<typeof Radio> = panda(Radio);
 
 export default PrimitiveRadioGroup;

--- a/src/components/primitives/Slider/Slider.tsx
+++ b/src/components/primitives/Slider/Slider.tsx
@@ -12,48 +12,52 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  SliderProps,
-  SliderControlProps,
-  SliderLabelProps,
-  SliderMarkerProps,
-  SliderMarkerGroupProps,
-  SliderOutputProps,
-  SliderRangeProps,
-  SliderThumbProps,
-  SliderTrackProps,
-} from "@ark-ui/react";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI slider primitives.
  */
-export type PrimitiveSliderProps = SliderProps;
-
+export type PrimitiveSliderProps = ComponentProps<typeof PrimitiveSlider>;
 const PrimitiveSlider = panda(Slider);
 
-export type PrimitiveSliderControlProps = SliderControlProps;
+export type PrimitiveSliderControlProps = ComponentProps<
+  typeof PrimitiveSliderControl
+>;
 export const PrimitiveSliderControl = panda(SliderControl);
 
-export type PrimitiveSliderLabelProps = SliderLabelProps;
+export type PrimitiveSliderLabelProps = ComponentProps<
+  typeof PrimitiveSliderLabel
+>;
 export const PrimitiveSliderLabel = panda(SliderLabel);
 
-export type PrimitiveSliderMarkerProps = SliderMarkerProps;
+export type PrimitiveSliderMarkerProps = ComponentProps<
+  typeof PrimitiveSliderMarker
+>;
 export const PrimitiveSliderMarker = panda(SliderMarker);
 
-export type PrimitiveSliderMarkerGroupProps = SliderMarkerGroupProps;
+export type PrimitiveSliderMarkerGroupProps = ComponentProps<
+  typeof PrimitiveSliderMarkerGroup
+>;
 export const PrimitiveSliderMarkerGroup = panda(SliderMarkerGroup);
 
-export type PrimitiveSliderOutputProps = SliderOutputProps;
-
+export type PrimitiveSliderOutputProps = ComponentProps<
+  typeof PrimitiveSliderOutput
+>;
 export const PrimitiveSliderOutput = panda(SliderOutput);
 
-export type PrimitiveSliderRangeProps = SliderRangeProps;
+export type PrimitiveSliderRangeProps = ComponentProps<
+  typeof PrimitiveSliderRange
+>;
 export const PrimitiveSliderRange = panda(SliderRange);
 
-export type PrimitiveSliderThumbProps = SliderThumbProps;
+export type PrimitiveSliderThumbProps = ComponentProps<
+  typeof PrimitiveSliderThumb
+>;
 export const PrimitiveSliderThumb = panda(SliderThumb);
 
-export type PrimitiveSliderTrackProps = SliderTrackProps;
+export type PrimitiveSliderTrackProps = ComponentProps<
+  typeof PrimitiveSliderTrack
+>;
 export const PrimitiveSliderTrack = panda(SliderTrack);
 
 export default PrimitiveSlider;

--- a/src/components/primitives/Tabs/Tabs.tsx
+++ b/src/components/primitives/Tabs/Tabs.tsx
@@ -8,33 +8,32 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  TabsProps,
-  TabContentProps,
-  TabIndicatorProps,
-  TabListProps,
-  TabTriggerProps,
-} from "@ark-ui/react";
 import type { PandaComponent } from "generated/panda/types/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI tabs primitives.
  */
-export type PrimitiveTabsProps = TabsProps;
+export type PrimitiveTabsProps = ComponentProps<typeof PrimitiveTabs>;
 const PrimitiveTabs: PandaComponent<typeof Tabs> = panda(Tabs);
 
-export type PrimitiveTabContentProps = TabContentProps;
+export type PrimitiveTabContentProps = ComponentProps<
+  typeof PrimitiveTabContent
+>;
 export const PrimitiveTabContent: PandaComponent<typeof TabContent> =
   panda(TabContent);
 
-export type PrimitiveTabIndicatorProps = TabIndicatorProps;
-export const PrimitiveTabIndicator: PandaComponent<typeof TabIndicator> =
-  panda(TabIndicator);
+export type PrimitiveTabIndicatorProps = ComponentProps<
+  typeof PrimitiveTabIndicator
+>;
+export const PrimitiveTabIndicator = panda(TabIndicator);
 
-export type PrimitiveTabListProps = TabListProps;
-export const PrimitiveTabList: PandaComponent<typeof TabList> = panda(TabList);
+export type PrimitiveTabListProps = ComponentProps<typeof PrimitiveTabList>;
+export const PrimitiveTabList = panda(TabList);
 
-export type PrimitiveTabTriggerProps = TabTriggerProps;
+export type PrimitiveTabTriggerProps = ComponentProps<
+  typeof PrimitiveTabTrigger
+>;
 export const PrimitiveTabTrigger: PandaComponent<typeof TabTrigger> =
   panda(TabTrigger);
 

--- a/src/components/primitives/Toggle/Toggle.tsx
+++ b/src/components/primitives/Toggle/Toggle.tsx
@@ -2,28 +2,28 @@ import { Switch, SwitchControl, SwitchThumb, SwitchLabel } from "@ark-ui/react";
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  SwitchProps,
-  SwitchControlProps,
-  SwitchThumbProps,
-  SwitchLabelProps,
-} from "@ark-ui/react";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI toggle primitives.
  */
-export type PrimitiveToggleProps = SwitchProps;
-
+export type PrimitiveToggleProps = ComponentProps<typeof PrimitiveToggle>;
 // NB: Using `Toggle` instead of `Switch` here to avoid recipe issues with `switch` being a reserved word.
 const PrimitiveToggle = panda(Switch);
 
-export type PrimitiveToggleControlProps = SwitchControlProps;
+export type PrimitiveToggleControlProps = ComponentProps<
+  typeof PrimitiveToggleControl
+>;
 export const PrimitiveToggleControl = panda(SwitchControl);
 
-export type PrimitiveToggleThumbProps = SwitchThumbProps;
+export type PrimitiveToggleThumbProps = ComponentProps<
+  typeof PrimitiveToggleThumb
+>;
 export const PrimitiveToggleThumb = panda(SwitchThumb);
 
-export type PrimitiveToggleLabelProps = SwitchLabelProps;
+export type PrimitiveToggleLabelProps = ComponentProps<
+  typeof PrimitiveToggleLabel
+>;
 export const PrimitiveToggleLabel = panda(SwitchLabel);
 
 export default PrimitiveToggle;

--- a/src/components/primitives/Tooltip/Tooltip.tsx
+++ b/src/components/primitives/Tooltip/Tooltip.tsx
@@ -9,36 +9,37 @@ import {
 
 import { panda } from "generated/panda/jsx";
 
-import type {
-  TooltipProps,
-  TooltipArrowProps,
-  TooltipArrowTipProps,
-  TooltipContentProps,
-  TooltipPositionerProps,
-  TooltipTriggerProps,
-} from "@ark-ui/react";
-import type { HTMLPandaProps } from "generated/panda/jsx";
+import type { ComponentProps } from "react";
 
 /**
  * Core UI tooltip primitives.
  */
-export type PrimitiveTooltipProps = TooltipProps;
+export type PrimitiveTooltipProps = ComponentProps<typeof PrimitiveTooltip>;
 const PrimitiveTooltip = panda(Tooltip);
 
-export type PrimitiveTooltipArrowProps = TooltipArrowProps;
+export type PrimitiveTooltipArrowProps = ComponentProps<
+  typeof PrimitiveTooltipArrow
+>;
 export const PrimitiveTooltipArrow = panda(TooltipArrow);
 
-export type PrimitiveTooltipArrowTipProps = TooltipArrowTipProps;
+export type PrimitiveTooltipArrowTipProps = ComponentProps<
+  typeof PrimitiveTooltipArrowTip
+>;
 export const PrimitiveTooltipArrowTip = panda(TooltipArrowTip);
 
-export type PrimitiveTooltipContentProps = TooltipContentProps;
+export type PrimitiveTooltipContentProps = ComponentProps<
+  typeof PrimitiveTooltipContent
+>;
 export const PrimitiveTooltipContent = panda(TooltipContent);
 
-export type PrimitiveTooltipPositionerProps = TooltipPositionerProps;
+export type PrimitiveTooltipPositionerProps = ComponentProps<
+  typeof PrimitiveTooltipPositioner
+>;
 export const PrimitiveTooltipPositioner = panda(TooltipPositioner);
 
-export type PrimitiveTooltipTriggerProps = TooltipTriggerProps &
-  HTMLPandaProps<"button">;
+export type PrimitiveTooltipTriggerProps = ComponentProps<
+  typeof PrimitiveTooltipTrigger
+>;
 export const PrimitiveTooltipTrigger = panda(TooltipTrigger);
 
 export default PrimitiveTooltip;


### PR DESCRIPTION
## Description

Updated all primitive component types to naturally include panda props.

## Test Steps

1) Verify that types for primitives look sound.
2) Verify that you can use panda style props (i.e. `mt` or `bgColor`) on all components naturally.
3) Verify that all tests pass.