### PR TITLE
Fix: Update Basic Recipe Component Structures

### DIFF
--- a/.changeset/hot-candles-dance.md
+++ b/.changeset/hot-candles-dance.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Fix `className` omission issue for basic recipe components when used as child for `asChild` components

--- a/src/components/core/Badge/Badge.tsx
+++ b/src/components/core/Badge/Badge.tsx
@@ -1,21 +1,13 @@
 import { panda } from "generated/panda/jsx";
 import { badge } from "generated/panda/recipes";
 
-import type { BadgeVariantProps } from "generated/panda/recipes";
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentProps } from "react";
 
-export type Props = ComponentPropsWithoutRef<typeof panda.div> &
-  BadgeVariantProps;
+export type Props = ComponentProps<typeof Badge>;
 
 /**
  * Core UI badge.
  */
-const Badge = ({ variant, size, children, ...props }: Props) => {
-  return (
-    <panda.div className={badge({ variant, size })} {...props}>
-      {children}
-    </panda.div>
-  );
-};
+const Badge = panda("div", badge);
 
 export default Badge;

--- a/src/components/core/Banner/Banner.tsx
+++ b/src/components/core/Banner/Banner.tsx
@@ -32,6 +32,7 @@ const Banner = ({ children, closable, ...rest }: Props) => {
           onClick={() => setIsOpen(false)}
           p={1}
           opacity={{ _hover: 0.8 }}
+          aria-label="Close Banner"
         >
           <Icon color="bg.default">
             <CloseIcon />

--- a/src/components/core/Banner/Banner.tsx
+++ b/src/components/core/Banner/Banner.tsx
@@ -6,25 +6,24 @@ import Icon from "components/core/Icon/Icon";
 import { panda } from "generated/panda/jsx";
 import { banner } from "generated/panda/recipes";
 
-import type { BannerVariantProps } from "generated/panda/recipes";
 import type { ComponentProps } from "react";
 
-export interface Props
-  extends ComponentProps<typeof panda.div>,
-    BannerVariantProps {
+export interface Props extends ComponentProps<typeof PandaBanner> {
   closable?: boolean;
 }
+
+const PandaBanner = panda("div", banner);
 
 /**
  * Core UI banner.
  */
-const Banner = ({ children, variant, closable, ...rest }: Props) => {
+const Banner = ({ children, closable, ...rest }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(true);
 
   if (!isOpen) return null;
 
   return (
-    <panda.div className={banner({ variant })} {...rest}>
+    <PandaBanner {...rest}>
       <panda.div flex={1} p={2}>
         {children}
       </panda.div>
@@ -32,17 +31,14 @@ const Banner = ({ children, variant, closable, ...rest }: Props) => {
         <Button
           onClick={() => setIsOpen(false)}
           p={1}
-          bgColor={{
-            base: "inherit",
-            _hover: "none",
-          }}
+          opacity={{ _hover: 0.8 }}
         >
           <Icon color="bg.default">
             <CloseIcon />
           </Icon>
         </Button>
       )}
-    </panda.div>
+    </PandaBanner>
   );
 };
 

--- a/src/components/core/Button/Button.tsx
+++ b/src/components/core/Button/Button.tsx
@@ -1,18 +1,13 @@
 import { panda } from "generated/panda/jsx";
 import { button } from "generated/panda/recipes";
 
-import type { ButtonVariantProps } from "generated/panda/recipes";
 import type { ComponentProps } from "react";
 
-export type Props = ComponentProps<typeof panda.button> & ButtonVariantProps;
+export type Props = ComponentProps<typeof Button>;
 
 /**
  * Core UI button.
  */
-const Button = ({ variant, size, children, ...rest }: Props) => (
-  <panda.button className={button({ variant, size })} {...rest}>
-    {children}
-  </panda.button>
-);
+const Button = panda("button", button);
 
 export default Button;

--- a/src/components/core/Icon/Icon.tsx
+++ b/src/components/core/Icon/Icon.tsx
@@ -3,11 +3,9 @@ import { ark } from "@ark-ui/react";
 import { panda } from "generated/panda/jsx";
 import { icon } from "generated/panda/recipes";
 
-import type { HTMLPandaProps } from "generated/panda/jsx";
-import type { IconVariantProps } from "generated/panda/recipes";
-import type { ReactElement } from "react";
+import type { ComponentProps, ReactElement } from "react";
 
-export interface Props extends IconVariantProps, HTMLPandaProps<"svg"> {
+export interface Props extends ComponentProps<typeof PandaIcon> {
   children: ReactElement;
 }
 

--- a/src/components/core/Image/Image.tsx
+++ b/src/components/core/Image/Image.tsx
@@ -1,18 +1,13 @@
 import { panda } from "generated/panda/jsx";
 import { image } from "generated/panda/recipes";
 
-import type { ImageVariantProps } from "generated/panda/recipes";
 import type { ComponentProps } from "react";
 
-export type Props = ComponentProps<typeof PandaImage> & ImageVariantProps;
-
-const PandaImage = panda("img");
+export type Props = ComponentProps<typeof Image>;
 
 /**
  * Core UI image.
  */
-const Image = ({ layout, ...rest }: Props) => {
-  return <PandaImage className={image({ layout })} {...rest} />;
-};
+const Image = panda("img", image);
 
 export default Image;

--- a/src/components/core/Spinner/Spinner.tsx
+++ b/src/components/core/Spinner/Spinner.tsx
@@ -1,17 +1,16 @@
 import { panda } from "generated/panda/jsx";
 import { spinner } from "generated/panda/recipes";
 
-import type { SpinnerVariantProps } from "generated/panda/recipes";
 import type { ComponentProps } from "react";
 
-export type Props = ComponentProps<typeof PandaSpinner> & SpinnerVariantProps;
+export type Props = ComponentProps<typeof PandaSpinner>;
 
-const PandaSpinner = panda("svg");
+const PandaSpinner = panda("svg", spinner);
 
 /**
  * Core Spinner component.
  */
-const Spinner = ({ size, ...props }: Props) => {
+const Spinner = ({ ...props }: Props) => {
   return (
     <PandaSpinner
       xmlns="http://www.w3.org/2000/svg"
@@ -19,7 +18,6 @@ const Spinner = ({ size, ...props }: Props) => {
       viewBox="0 0 24 24"
       animation="infinite-spin"
       role="spinner"
-      className={spinner({ size })}
       {...props}
     >
       <panda.path

--- a/src/components/core/Text/Text.tsx
+++ b/src/components/core/Text/Text.tsx
@@ -1,20 +1,13 @@
 import { panda } from "generated/panda/jsx";
 import { text } from "generated/panda/recipes";
 
-import type { TextVariantProps } from "generated/panda/recipes";
 import type { ComponentProps } from "react";
 
-export type Props = ComponentProps<typeof PandaText> & TextVariantProps;
-
-const PandaText = panda("p", text);
+export type Props = ComponentProps<typeof Text>;
 
 /**
  * Core UI text (typography).
  */
-const Text = ({ size, children, ...rest }: Props) => (
-  <PandaText className={text({ size })} {...rest}>
-    {children}
-  </PandaText>
-);
+const Text = panda("p", text);
 
 export default Text;

--- a/src/components/utility/Hide/Hide.tsx
+++ b/src/components/utility/Hide/Hide.tsx
@@ -1,20 +1,13 @@
 import { panda } from "generated/panda/jsx";
 import { hide } from "generated/panda/recipes";
 
-import type { HideVariantProps } from "generated/panda/recipes";
 import type { ComponentProps } from "react";
 
-export type Props = ComponentProps<typeof panda.div> & HideVariantProps;
+export type Props = ComponentProps<typeof Hide>;
 
 /**
  * Utility component to conditionally hide child elements from or below defined breakpoints.
  */
-const Hide = ({ children, below, from, ...rest }: Props) => {
-  return (
-    <panda.div className={hide({ below, from })} {...rest}>
-      {children}
-    </panda.div>
-  );
-};
+const Hide = panda("div", hide);
 
 export default Hide;

--- a/src/components/utility/Show/Show.tsx
+++ b/src/components/utility/Show/Show.tsx
@@ -1,20 +1,13 @@
 import { panda } from "generated/panda/jsx";
 import { show } from "generated/panda/recipes";
 
-import type { ShowVariantProps } from "generated/panda/recipes";
 import type { ComponentProps } from "react";
 
-export type Props = ComponentProps<typeof panda.div> & ShowVariantProps;
+export type Props = ComponentProps<typeof Show>;
 
 /**
  * Utility component to conditionally render child elements from or below defined breakpoints.
  */
-const Show = ({ children, below, from, ...rest }: Props) => {
-  return (
-    <panda.div className={show({ below, from })} {...rest}>
-      {children}
-    </panda.div>
-  );
-};
+const Show = panda("div", show);
 
 export default Show;


### PR DESCRIPTION
## Description

Updated component structures for components that follow basic recipes (not slot). The previous pattern caused conflict downstream with `asChild` prop, classes were being omitted. User facing API is unchanged.

## Test Steps

1) Verify structure of components seems sound.
2) Verify styles and variants render appropriately in storybook and in downstream example apps (with no erros, as the API should be the same for each component).
3) Verify that all tests pass.
