### PR TITLE
Update Collapse Component to allow for Controlled State

### DIFF
--- a/.changeset/thirty-timers-suffer.md
+++ b/.changeset/thirty-timers-suffer.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": minor
+---
+
+Update `Collapse` to accept controlled state props

--- a/src/components/utility/Collapse/Collapse.stories.tsx
+++ b/src/components/utility/Collapse/Collapse.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { collapseState } from "./Collapse.spec";
 import { Image, Text } from "components/core";
 import { Collapse } from "components/utility";
@@ -7,10 +9,28 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 type Story = StoryObj<typeof Collapse>;
 
+const ControlledExample = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Collapse
+      label={isOpen ? "Show Less" : "Show More"}
+      isOpen={isOpen}
+      onOpen={() => setIsOpen(true)}
+      onClose={() => setIsOpen(false)}
+    >
+      <Text p={2} bgColor="bg.muted">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </Text>
+    </Collapse>
+  );
+};
+
 export const Vertical: Story = {
   render: () => (
     <Flex direction="column" gap={2}>
-      <Collapse label="Show More">
+      <Collapse>
         <Image src="/img/logo.png" alt="AR logo" height={40} width={40} />
       </Collapse>
       <Text p={2} bgColor="bg.muted">
@@ -33,6 +53,10 @@ export const Horizontal: Story = {
       </Text>
     </Flex>
   ),
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledExample />,
 };
 
 export const CollapseState: Story = {

--- a/src/components/utility/Collapse/Collapse.tsx
+++ b/src/components/utility/Collapse/Collapse.tsx
@@ -1,20 +1,24 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { useState } from "react";
 import { FiChevronDown, FiChevronRight } from "react-icons/fi";
 
 import Button from "components/core/Button/Button";
 import Icon from "components/core/Icon/Icon";
 import { Flex } from "generated/panda/jsx";
+import { useDisclosure } from "lib/hooks";
 
+import type { Props as ButtonProps } from "components/core/Button/Button";
 import type { FlexProps } from "generated/panda/jsx";
 import type { ReactElement, ReactNode } from "react";
 
 export interface Props extends FlexProps {
   label?: string;
   icon?: ReactElement;
-  open?: boolean;
+  isOpen?: boolean;
+  onOpen?: () => void;
+  onClose?: () => void;
   children?: ReactNode;
   collapseDirection?: "horizontal" | "vertical";
+  triggerProps?: ButtonProps;
 }
 
 /**
@@ -23,12 +27,19 @@ export interface Props extends FlexProps {
 const Collapse = ({
   label,
   icon,
-  open,
+  isOpen: isOpenProp,
+  onOpen,
+  onClose,
   children,
   collapseDirection = "vertical",
+  triggerProps,
   ...rest
 }: Props) => {
-  const [isOpen, setIsOpen] = useState(open ?? false);
+  const { isOpen, onToggle } = useDisclosure({
+    isOpen: isOpenProp,
+    onOpen,
+    onClose,
+  });
 
   const isHorizontal = collapseDirection == "horizontal";
   const defaultIcon = isHorizontal ? <FiChevronRight /> : <FiChevronDown />;
@@ -36,13 +47,13 @@ const Collapse = ({
   return (
     <Flex direction={isHorizontal ? "row-reverse" : "column"} gap={2} {...rest}>
       <Button
+        w="fit-content"
+        gap={1}
         display="flex"
         alignItems="center"
-        gap={2}
-        variant="ghost"
-        w="fit-content"
-        size="sm"
-        onClick={() => setIsOpen(!isOpen)}
+        placeSelf={isHorizontal ? "flex-start" : undefined}
+        onClick={() => onToggle()}
+        {...triggerProps}
       >
         {label}
         <Icon transform={isOpen && !icon ? "rotate(-180deg)" : undefined}>


### PR DESCRIPTION
## Description

Added optional `isOpen`, `onOpen`, and `onClose` props (using the `useDisclose` hook) to allow for a controlled experience with the `Collapse` component.

## Test Steps

1) Verify logic is sound.
2) Verify that `Collapse` stories and demos in example apps render appropriately (and function as expected).
3) Verify all tests pass.
