### PR TITLE
Utilize Default Variants

### DIFF
--- a/.changeset/witty-roses-draw.md
+++ b/.changeset/witty-roses-draw.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Add additional variants for components that leverage `defaultVariants`

--- a/src/components/core/Avatar/Avatar.recipe.ts
+++ b/src/components/core/Avatar/Avatar.recipe.ts
@@ -7,11 +7,8 @@ export const avatarRecipe = defineSlotRecipe({
   slots: avatarAnatomy.keys(),
   base: {
     root: {
-      height: 10,
-      width: 10,
       m: "-1px",
       borderColor: "border.default",
-      borderRadius: "full",
       borderWidth: "1px",
       flexShrink: 0,
     },
@@ -28,8 +25,17 @@ export const avatarRecipe = defineSlotRecipe({
       objectFit: "cover",
     },
   },
+  defaultVariants: {
+    variant: "round",
+    size: "md",
+  },
   variants: {
     variant: {
+      round: {
+        root: {
+          borderRadius: "full",
+        },
+      },
       square: {
         root: {
           borderRadius: "lg",
@@ -53,6 +59,15 @@ export const avatarRecipe = defineSlotRecipe({
         },
         fallback: {
           textStyle: "sm",
+        },
+      },
+      md: {
+        root: {
+          height: 10,
+          width: 10,
+        },
+        fallback: {
+          textStyle: "md",
         },
       },
       lg: {

--- a/src/components/core/Badge/Badge.recipe.ts
+++ b/src/components/core/Badge/Badge.recipe.ts
@@ -11,15 +11,17 @@ export const badgeRecipe = defineRecipe({
     alignItems: "center",
     userSelect: "none",
     whiteSpace: "nowrap",
-    textStyle: "sm",
-    px: 2.5,
-    h: 6,
-    gap: 2,
-    background: "accent.default",
-    color: "accent.fg",
+  },
+  defaultVariants: {
+    variant: "primary",
+    size: "md",
   },
   variants: {
     variant: {
+      primary: {
+        background: "accent.default",
+        color: "accent.fg",
+      },
       subtle: {
         background: "accent.subtle",
         borderColor: "border.accent",
@@ -35,6 +37,7 @@ export const badgeRecipe = defineRecipe({
     },
     size: {
       sm: { textStyle: "xs", px: 2, h: 5, gap: 1 },
+      md: { textStyle: "sm", px: 2.5, h: 6, gap: 2 },
       lg: { textStyle: "sm", px: 3, h: 7, gap: 1.5 },
     },
   },

--- a/src/components/core/Badge/Badge.stories.tsx
+++ b/src/components/core/Badge/Badge.stories.tsx
@@ -8,11 +8,15 @@ type Story = StoryObj<typeof Badge>;
 export const Default: Story = {
   render: () => <Badge>Badge</Badge>,
 };
-export const Subtle: Story = {
-  render: () => <Badge variant="subtle">Badge</Badge>,
-};
-export const Outline: Story = {
-  render: () => <Badge variant="outline">Badge</Badge>,
+
+export const Variants: Story = {
+  render: () => (
+    <Flex gap={2}>
+      <Badge variant="primary">Badge</Badge>
+      <Badge variant="subtle">Badge</Badge>
+      <Badge variant="outline">Badge</Badge>
+    </Flex>
+  ),
 };
 
 export const Sizes: Story = {

--- a/src/components/core/Button/Button.recipe.ts
+++ b/src/components/core/Button/Button.recipe.ts
@@ -6,7 +6,6 @@ export const buttonRecipe = defineRecipe({
   base: {
     cursor: "pointer",
     fontWeight: "bold",
-    p: 3,
     borderRadius: "md",
     display: "inline-flex",
     alignItems: "center",
@@ -20,6 +19,10 @@ export const buttonRecipe = defineRecipe({
         bgColor: "bg.disabled",
       },
     },
+  },
+  defaultVariants: {
+    variant: "primary",
+    size: "md",
   },
   variants: {
     variant: {
@@ -96,6 +99,10 @@ export const buttonRecipe = defineRecipe({
       sm: {
         fontSize: "sm",
         p: 2.5,
+      },
+      md: {
+        fontSize: "md",
+        p: 3,
       },
       lg: {
         fontSize: "lg",

--- a/src/components/core/Button/Button.stories.tsx
+++ b/src/components/core/Button/Button.stories.tsx
@@ -20,7 +20,6 @@ export const Variants: Story = {
   render: () => (
     <Flex gap={2}>
       <Button>Click me 🏝️</Button>
-      <Button variant="primary">Click me 🏝️</Button>
       <Button variant="secondary">Click me 🏝️</Button>
       <Button variant="ghost">Click me 🏝️</Button>
       <Button variant="round">Click me 🏝️</Button>

--- a/src/components/core/Carousel/Carousel.recipe.ts
+++ b/src/components/core/Carousel/Carousel.recipe.ts
@@ -42,19 +42,14 @@ export const carouselRecipe = defineSlotRecipe({
       position: "absolute",
       transform: "translateX(-50%)",
       zIndex: "docked",
-      gap: 2,
-      p: 2.5,
     },
     indicatorGroup: {
       display: "flex",
-      gap: 3,
     },
     indicator: {
       borderRadius: "full",
       background: "bg.emphasized",
       cursor: "pointer",
-      width: 2.5,
-      height: 2.5,
       _current: {
         background: "accent.default",
       },
@@ -66,6 +61,9 @@ export const carouselRecipe = defineSlotRecipe({
     },
     nextSlideTrigger: triggerStyle,
     prevSlideTrigger: triggerStyle,
+  },
+  defaultVariants: {
+    size: "md",
   },
   variants: {
     size: {
@@ -80,6 +78,19 @@ export const carouselRecipe = defineSlotRecipe({
         indicator: {
           width: 2,
           height: 2,
+        },
+      },
+      md: {
+        control: {
+          gap: 2,
+          p: 2.5,
+        },
+        indicatorGroup: {
+          gap: 3,
+        },
+        indicator: {
+          width: 2.5,
+          height: 2.5,
         },
       },
     },

--- a/src/components/core/Checkbox/Checkbox.recipe.ts
+++ b/src/components/core/Checkbox/Checkbox.recipe.ts
@@ -10,12 +10,10 @@ export const checkboxRecipe = defineSlotRecipe({
       w: "100%",
       alignItems: "center",
       display: "flex",
-      gap: 3,
     },
     label: {
       color: "fg.emphasized",
       fontWeight: "medium",
-      textStyle: "md",
       flex: 1,
     },
     control: {
@@ -25,13 +23,6 @@ export const checkboxRecipe = defineSlotRecipe({
       color: "accent.fg",
       cursor: "pointer",
       display: "flex",
-      width: 5,
-      height: 5,
-      borderRadius: "xs",
-      "& svg": {
-        width: 3.5,
-        height: 3.5,
-      },
       justifyContent: "center",
       transitionDuration: "normal",
       transitionProperty: "border-color, background",
@@ -47,6 +38,9 @@ export const checkboxRecipe = defineSlotRecipe({
         },
       },
     },
+  },
+  defaultVariants: {
+    size: "md",
   },
   variants: {
     size: {
@@ -65,6 +59,23 @@ export const checkboxRecipe = defineSlotRecipe({
         },
         label: {
           textStyle: "sm",
+        },
+      },
+      md: {
+        root: {
+          gap: 3,
+        },
+        control: {
+          width: 5,
+          height: 5,
+          borderRadius: "xs",
+          "& svg": {
+            width: 3.5,
+            height: 3.5,
+          },
+        },
+        label: {
+          textStyle: "md",
         },
       },
       lg: {

--- a/src/components/core/Icon/Icon.recipe.ts
+++ b/src/components/core/Icon/Icon.recipe.ts
@@ -8,8 +8,9 @@ export const iconRecipe = defineRecipe({
     flexShrink: 0,
     verticalAlign: "middle",
     lineHeight: "1em",
-    w: 5,
-    h: 5,
+  },
+  defaultVariants: {
+    size: "md",
   },
   variants: {
     size: {
@@ -20,6 +21,10 @@ export const iconRecipe = defineRecipe({
       sm: {
         w: 4,
         h: 4,
+      },
+      md: {
+        w: 5,
+        h: 5,
       },
       lg: {
         w: 6,

--- a/src/components/core/Input/Input.recipe.ts
+++ b/src/components/core/Input/Input.recipe.ts
@@ -9,13 +9,6 @@ export const inputRecipe = defineSlotRecipe({
       appearance: "none",
       color: "fg.default",
       caretColor: "accent.default",
-      backgroundColor: "bg.default",
-      borderColor: "border.default",
-      borderWidth: "1px",
-      px: 3,
-      h: 10,
-      minW: 10,
-      fontSize: "md",
       outline: 0,
       position: "relative",
       transitionDuration: "normal",
@@ -26,18 +19,11 @@ export const inputRecipe = defineSlotRecipe({
         opacity: 0.4,
         cursor: "not-allowed",
       },
-      _focus: {
-        borderColor: "border.accent",
-        boxShadow: "sm",
-      },
     },
     label: {
-      fontWeight: "md",
       color: "fg.emphasized",
     },
     addon: {
-      fontSize: "md",
-      px: 3,
       display: "flex",
       alignItems: "center",
       backgroundColor: "border.default",
@@ -58,8 +44,23 @@ export const inputRecipe = defineSlotRecipe({
       color: "fg.subtle",
     },
   },
+  defaultVariants: {
+    variant: "primary",
+    size: "md",
+  },
   variants: {
     variant: {
+      primary: {
+        input: {
+          backgroundColor: "bg.default",
+          borderWidth: "1px",
+          borderColor: "border.default",
+          _focus: {
+            borderColor: "border.accent",
+            boxShadow: "sm",
+          },
+        },
+      },
       flushed: {
         input: {
           backgroundColor: "transparent",
@@ -74,6 +75,8 @@ export const inputRecipe = defineSlotRecipe({
       filled: {
         input: {
           backgroundColor: "border.default",
+          borderWidth: "1px",
+          borderColor: "border.default",
           _focus: {
             backgroundColor: "bg.default",
             borderColor: "border.accent",
@@ -87,6 +90,7 @@ export const inputRecipe = defineSlotRecipe({
           borderWidth: 0,
           borderRadius: 0,
           _focus: {
+            borderColor: "border.accent",
             boxShadow: "none",
           },
         },
@@ -113,6 +117,13 @@ export const inputRecipe = defineSlotRecipe({
         addon: { fontSize: "sm", px: 2.5 },
         leftElement: { fontSize: "sm" },
         rightElement: { fontSize: "sm" },
+      },
+      md: {
+        input: { px: 3, h: 10, minW: 10, fontSize: "md" },
+        label: { fontSize: "md" },
+        addon: { fontSize: "md", px: 3 },
+        leftElement: { fontSize: "md" },
+        rightElement: { fontSize: "md" },
       },
       lg: {
         input: { px: 3.5, h: 11, minW: 11, fontSize: "md" },

--- a/src/components/core/Menu/Menu.recipe.ts
+++ b/src/components/core/Menu/Menu.recipe.ts
@@ -7,8 +7,6 @@ const itemStyle = {
   cursor: "pointer",
   color: "fg.default",
   display: "flex",
-  h: 10,
-  px: 2.5,
   mx: 1,
   fontWeight: "medium",
   textStyle: "sm",
@@ -38,7 +36,6 @@ export const menuRecipe = defineSlotRecipe({
       borderBottomWidth: "1px",
       borderBottomColor: "border.default",
       color: "fg.default",
-      p: 1.5,
     },
     content: {
       background: "bg.default",
@@ -54,7 +51,6 @@ export const menuRecipe = defineSlotRecipe({
       outline: "none",
       py: 1,
       gap: 1,
-      minW: 44,
     },
     separator: {
       color: "bg.subtle",
@@ -73,6 +69,9 @@ export const menuRecipe = defineSlotRecipe({
     trigger: {
       w: "fit-content",
     },
+  },
+  defaultVariants: {
+    size: "md",
   },
   variants: {
     size: {
@@ -94,6 +93,26 @@ export const menuRecipe = defineSlotRecipe({
         triggerItem: {
           h: 9,
           px: 2,
+        },
+      },
+      md: {
+        itemGroupLabel: {
+          p: 1.5,
+        },
+        content: {
+          minW: 44,
+        },
+        item: {
+          h: 10,
+          px: 2.5,
+        },
+        optionItem: {
+          h: 10,
+          px: 2.5,
+        },
+        triggerItem: {
+          h: 10,
+          px: 2.5,
         },
       },
       lg: {

--- a/src/components/core/NumberInput/NumberInput.recipe.ts
+++ b/src/components/core/NumberInput/NumberInput.recipe.ts
@@ -43,13 +43,6 @@ export const numberInputRecipe = defineSlotRecipe({
       },
       color: "fg.default",
       caretColor: "accent.default",
-      backgroundColor: "bg.default",
-      borderColor: "border.default",
-      borderWidth: "1px",
-      px: 3,
-      h: 10,
-      minW: 10,
-      fontSize: "md",
       outline: 0,
       position: "relative",
       transitionDuration: "normal",
@@ -60,25 +53,17 @@ export const numberInputRecipe = defineSlotRecipe({
         opacity: 0.4,
         cursor: "not-allowed",
       },
-      _focus: {
-        borderColor: "border.accent",
-        boxShadow: "sm",
-      },
     },
     label: {
-      fontWeight: "md",
       color: "fg.emphasized",
     },
     addon: {
-      fontSize: "md",
-      px: 3,
       display: "flex",
       alignItems: "center",
       backgroundColor: "border.default",
       color: "fg.default",
     },
     stepper: {
-      fontSize: "md",
       display: "flex",
       alignItems: "center",
       backgroundColor: "border.default",
@@ -106,8 +91,23 @@ export const numberInputRecipe = defineSlotRecipe({
       color: "fg.subtle",
     },
   },
+  defaultVariants: {
+    variant: "primary",
+    size: "md",
+  },
   variants: {
     variant: {
+      primary: {
+        input: {
+          backgroundColor: "bg.default",
+          borderWidth: "1px",
+          borderColor: "border.default",
+          _focus: {
+            borderColor: "border.accent",
+            boxShadow: "sm",
+          },
+        },
+      },
       flushed: {
         input: {
           backgroundColor: "transparent",
@@ -122,6 +122,8 @@ export const numberInputRecipe = defineSlotRecipe({
       filled: {
         input: {
           backgroundColor: "border.default",
+          borderWidth: "1px",
+          borderColor: "border.default",
           _focus: {
             backgroundColor: "bg.default",
             borderColor: "border.accent",
@@ -133,8 +135,10 @@ export const numberInputRecipe = defineSlotRecipe({
         input: {
           backgroundColor: "transparent",
           borderWidth: 0,
+          borderColor: "border.default",
           borderRadius: 0,
           _focus: {
+            borderColor: "border.accent",
             boxShadow: "none",
           },
         },
@@ -164,6 +168,14 @@ export const numberInputRecipe = defineSlotRecipe({
         stepper: { fontSize: "sm" },
         leftElement: { fontSize: "sm" },
         rightElement: { fontSize: "sm" },
+      },
+      md: {
+        input: { px: 3, h: 10, minW: 10, fontSize: "md" },
+        label: { fontSize: "md" },
+        addon: { fontSize: "md", px: 3 },
+        stepper: { fontSize: "md" },
+        leftElement: { fontSize: "md" },
+        rightElement: { fontSize: "md" },
       },
       lg: {
         input: { px: 3.5, h: 11, minW: 11, fontSize: "md" },

--- a/src/components/core/RadioGroup/RadioGroup.recipe.ts
+++ b/src/components/core/RadioGroup/RadioGroup.recipe.ts
@@ -15,10 +15,6 @@ export const radioGroupRecipe = defineSlotRecipe({
         _horizontal: "row",
       },
       size: "md",
-      gap: {
-        _vertical: "4",
-        _horizontal: "6",
-      },
     },
     radioControl: {
       background: "transparent",
@@ -28,8 +24,6 @@ export const radioGroupRecipe = defineSlotRecipe({
       transitionDuration: "normal",
       transitionProperty: "background",
       transitionTimingFunction: "default",
-      width: "5",
-      height: "5",
       _hover: {
         background: "bg.muted",
       },
@@ -38,8 +32,6 @@ export const radioGroupRecipe = defineSlotRecipe({
         borderColor: "border.accent",
         outlineColor: "bg.default",
         outlineStyle: "solid",
-        outlineWidth: "4px",
-        outlineOffset: "-5px",
         _hover: {
           background: "accent.default",
         },
@@ -61,32 +53,33 @@ export const radioGroupRecipe = defineSlotRecipe({
       _disabled: {
         cursor: "not-allowed",
       },
-      gap: "3",
     },
     radioLabel: {
       color: "fg.emphasized",
       fontWeight: "medium",
-      textStyle: "md",
       _disabled: {
         color: "fg.subtle",
       },
     },
+  },
+  defaultVariants: {
+    size: "md",
   },
   variants: {
     size: {
       sm: {
         root: {
           gap: {
-            _vertical: "3",
-            _horizontal: "4",
+            _vertical: 3,
+            _horizontal: 4,
           },
         },
         radio: {
-          gap: "2",
+          gap: 2,
         },
         radioControl: {
-          width: "4",
-          height: "4",
+          width: 4,
+          height: 4,
           _checked: {
             outlineWidth: "3px",
             outlineOffset: "-4px",
@@ -96,19 +89,41 @@ export const radioGroupRecipe = defineSlotRecipe({
           textStyle: "sm",
         },
       },
-      lg: {
+      md: {
         root: {
           gap: {
-            _vertical: "5",
-            _horizontal: "8",
+            _vertical: 4,
+            _horizontal: 6,
           },
         },
         radio: {
-          gap: "4",
+          gap: 3,
         },
         radioControl: {
-          width: "6",
-          height: "6",
+          width: 5,
+          height: 5,
+          _checked: {
+            outlineWidth: "4px",
+            outlineOffset: "-5px",
+          },
+        },
+        radioLabel: {
+          textStyle: "md",
+        },
+      },
+      lg: {
+        root: {
+          gap: {
+            _vertical: 5,
+            _horizontal: 8,
+          },
+        },
+        radio: {
+          gap: 4,
+        },
+        radioControl: {
+          width: 6,
+          height: 6,
           _checked: {
             outlineWidth: "5px",
             outlineOffset: "-6px",

--- a/src/components/core/Spinner/Spinner.recipe.ts
+++ b/src/components/core/Spinner/Spinner.recipe.ts
@@ -5,15 +5,20 @@ export const spinnerRecipe = defineRecipe({
   description: "The styles for the Spinner component",
   base: {
     color: "accent.default",
-    h: 9,
-    w: 9,
     animation: "infinite-spin",
+  },
+  defaultVariants: {
+    size: "md",
   },
   variants: {
     size: {
       sm: {
         h: 6,
         w: 6,
+      },
+      md: {
+        h: 9,
+        w: 9,
       },
       lg: {
         h: 12,

--- a/src/components/core/Stat/Stat.recipe.ts
+++ b/src/components/core/Stat/Stat.recipe.ts
@@ -7,37 +7,40 @@ export const statRecipe = defineSlotRecipe({
   base: {
     root: {
       display: "flex",
-      flexDirection: "column",
-      alignItems: "start",
-      borderRadius: "md",
-      boxShadow: "sm",
-      bgColor: "bg.default",
-      borderWidth: "1px",
-      borderColor: "border.default",
-      color: "fg.default",
       w: "fit",
-      px: 4,
-      py: 2,
-      gap: 0,
     },
     helpText: {
-      textStyle: "sm",
       fontWeight: "light",
     },
     label: {
-      textStyle: "md",
       fontWeight: "normal",
     },
     value: {
-      textStyle: "lg",
       fontWeight: "bold",
     },
   },
+  defaultVariants: {
+    variant: "primary",
+    orientation: "horizontal",
+    size: "md",
+  },
   variants: {
     variant: {
+      primary: {
+        root: {
+          bgColor: "bg.default",
+          borderColor: "border.default",
+          color: "fg.default",
+          boxShadow: "sm",
+          borderWidth: "1px",
+          borderRadius: "md",
+        },
+      },
       unstyled: {
         root: {
           bgColor: "transparent",
+          borderColor: "border.default",
+          color: "fg.default",
           boxShadow: "none",
           borderWidth: 0,
           borderRadius: 0,
@@ -47,12 +50,20 @@ export const statRecipe = defineSlotRecipe({
         root: {
           bgColor: "transparent",
           borderColor: "accent.default",
+          color: "fg.default",
+          boxShadow: "sm",
+          borderWidth: "1px",
+          borderRadius: "md",
         },
       },
       subtle: {
         root: {
           bgColor: "bg.subtle",
+          borderColor: "border.default",
+          color: "fg.default",
+          boxShadow: "sm",
           borderWidth: 0,
+          borderRadius: "md",
         },
       },
     },
@@ -78,6 +89,12 @@ export const statRecipe = defineSlotRecipe({
         helpText: { textStyle: "xs" },
         label: { textStyle: "sm" },
         value: { textStyle: "md" },
+      },
+      md: {
+        root: { px: 4, py: 2 },
+        helpText: { textStyle: "sm" },
+        label: { textStyle: "md" },
+        value: { textStyle: "lg" },
       },
       lg: {
         root: { px: 6, py: 3 },

--- a/src/components/core/Tabs/Tabs.recipe.ts
+++ b/src/components/core/Tabs/Tabs.recipe.ts
@@ -88,13 +88,4 @@ export const tabsRecipe = defineSlotRecipe({
       color: "fg.default",
     },
   },
-  variants: {
-    size: {
-      sm: {
-        trigger: {
-          textStyle: "sm",
-        },
-      },
-    },
-  },
 });

--- a/src/components/core/Tabs/Tabs.tsx
+++ b/src/components/core/Tabs/Tabs.tsx
@@ -9,7 +9,6 @@ import { tabs as tabsRecipe } from "generated/panda/recipes";
 import { useIsClient } from "lib/hooks";
 
 import type { PrimitiveTabsProps } from "components/primitives";
-import type { TabsVariantProps } from "generated/panda/recipes";
 import type { ReactNode } from "react";
 
 export interface TabRecord {
@@ -21,15 +20,15 @@ export interface TabRecord {
   content: ReactNode;
 }
 
-export interface Props extends PrimitiveTabsProps, TabsVariantProps {
+export interface Props extends PrimitiveTabsProps {
   tabs: TabRecord[];
 }
 
 /**
  * Core UI tabs.
  */
-const Tabs = ({ tabs, size, ...rest }: Props) => {
-  const classNames = tabsRecipe({ size });
+const Tabs = ({ tabs, ...rest }: Props) => {
+  const classNames = tabsRecipe();
 
   const isClient = useIsClient();
 

--- a/src/components/core/Text/Text.recipe.ts
+++ b/src/components/core/Text/Text.recipe.ts
@@ -6,9 +6,13 @@ export const textRecipe = defineRecipe({
   base: {
     color: "fg.default",
   },
+  defaultVariants: {
+    size: "md",
+  },
   variants: {
     size: {
       sm: { fontSize: "sm" },
+      md: { fontSize: "md" },
       lg: { fontSize: "lg" },
     },
   },

--- a/src/components/core/Textarea/Textarea.recipe.ts
+++ b/src/components/core/Textarea/Textarea.recipe.ts
@@ -6,16 +6,10 @@ export const textareaRecipe = defineSlotRecipe({
   slots: ["label", "textarea"],
   base: {
     textarea: {
-      backgroundColor: "bg.default",
       color: "fg.default",
       appearance: "none",
       borderColor: "border.default",
-      borderRadius: "sm",
-      borderWidth: "1px",
-      minW: 10,
       outline: 0,
-      p: 3,
-      fontSize: "md",
       position: "relative",
       transitionDuration: "normal",
       transitionProperty: "box-shadow, border-color",
@@ -24,18 +18,28 @@ export const textareaRecipe = defineSlotRecipe({
         opacity: 0.4,
         cursor: "not-allowed",
       },
-      _focus: {
-        borderColor: "border.accent",
-        boxShadow: "sm",
-      },
     },
     label: {
-      fontWeight: "md",
       color: "fg.emphasized",
     },
   },
+  defaultVariants: {
+    variant: "primary",
+    size: "md",
+  },
   variants: {
     variant: {
+      primary: {
+        textarea: {
+          backgroundColor: "bg.default",
+          borderWidth: "1px",
+          borderRadius: "sm",
+          _focus: {
+            borderColor: "border.accent",
+            boxShadow: "sm",
+          },
+        },
+      },
       flushed: {
         textarea: {
           backgroundColor: "transparent",
@@ -50,6 +54,8 @@ export const textareaRecipe = defineSlotRecipe({
       filled: {
         textarea: {
           backgroundColor: "border.default",
+          borderWidth: "1px",
+          borderRadius: "sm",
           _focus: {
             backgroundColor: "bg.default",
             borderColor: "border.accent",
@@ -63,6 +69,7 @@ export const textareaRecipe = defineSlotRecipe({
           borderWidth: 0,
           borderRadius: 0,
           _focus: {
+            borderColor: "border.accent",
             boxShadow: "none",
           },
         },
@@ -76,6 +83,10 @@ export const textareaRecipe = defineSlotRecipe({
       sm: {
         textarea: { p: 2.5, minW: 9, fontSize: "sm" },
         label: { fontSize: "sm" },
+      },
+      md: {
+        textarea: { p: 3, minW: 10, fontSize: "md" },
+        label: { fontSize: "md" },
       },
       lg: {
         textarea: { p: 3.5, minW: 11, fontSize: "md" },

--- a/src/components/core/Toggle/Toggle.recipe.ts
+++ b/src/components/core/Toggle/Toggle.recipe.ts
@@ -10,7 +10,6 @@ export const toggleRecipe = defineSlotRecipe({
       alignItems: "center",
       display: "flex",
       position: "relative",
-      gap: 3,
     },
     control: {
       alignItems: "center",
@@ -19,8 +18,6 @@ export const toggleRecipe = defineSlotRecipe({
       cursor: "pointer",
       display: "inline-flex",
       flexShrink: 0,
-      width: 9,
-      p: 0.5,
       transitionDuration: "normal",
       transitionProperty: "background",
       transitionTimingFunction: "default",
@@ -30,7 +27,6 @@ export const toggleRecipe = defineSlotRecipe({
     },
     label: {
       userSelect: "none",
-      textStyle: "md",
       fontWeight: "medium",
       color: "fg.default",
     },
@@ -38,8 +34,6 @@ export const toggleRecipe = defineSlotRecipe({
       background: "bg.default",
       borderRadius: "full",
       boxShadow: "xs",
-      height: 4,
-      width: 4,
       transitionDuration: "normal",
       transitionProperty: "transform, background",
       transitionTimingFunction: "default",
@@ -48,6 +42,9 @@ export const toggleRecipe = defineSlotRecipe({
         background: "bg.default",
       },
     },
+  },
+  defaultVariants: {
+    size: "md",
   },
   variants: {
     size: {
@@ -65,6 +62,22 @@ export const toggleRecipe = defineSlotRecipe({
         },
         label: {
           textStyle: "sm",
+        },
+      },
+      md: {
+        root: {
+          gap: 3,
+        },
+        control: {
+          width: 9,
+          p: 0.5,
+        },
+        thumb: {
+          width: 4,
+          height: 4,
+        },
+        label: {
+          textStyle: "md",
         },
       },
       lg: {


### PR DESCRIPTION
## Description

Added default variants and removed variant styles from `base` for all applicable components. This simplifies our recipe patterns, as well as removes issues downstream with unexpected cascade layer conflicts.

## Test Steps

1) Most importantly, test that all components and their variants render as expected. Nothing about the styling should seem different than our previous component styles.
2) Verify that structure of updated recipes seem sound. If there are any nit changes to the recipes you would like to see made, this would be a good PR to add in those changes due to its overarching scope, so let me know!
2) Verify that all tests pass.
