### PR TITLE
Update close trigger styles

### DIFF
--- a/.changeset/ninety-snails-breathe.md
+++ b/.changeset/ninety-snails-breathe.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Fix all `closeTrigger` recipe styles

--- a/src/components/core/Drawer/Drawer.recipe.ts
+++ b/src/components/core/Drawer/Drawer.recipe.ts
@@ -57,12 +57,13 @@ export const drawerRecipe = defineSlotRecipe({
       },
     },
     closeTrigger: {
+      display: "flex",
       cursor: "pointer",
       borderRadius: "md",
       pos: "absolute",
-      top: 2,
-      right: 2,
-      p: 3,
+      top: 3,
+      right: 3,
+      p: 2,
       bgColor: {
         base: "inherit",
         _hover: "bg.subtle",

--- a/src/components/core/Flyout/Flyout.recipe.ts
+++ b/src/components/core/Flyout/Flyout.recipe.ts
@@ -4,7 +4,7 @@ import { defineSlotRecipe } from "@pandacss/dev";
 export const flyoutRecipe = defineSlotRecipe({
   className: "flyout",
   description: "The styles for the Flyout component",
-  slots: [...popoverAnatomy.keys(), "closeTriggerIcon"],
+  slots: [...popoverAnatomy.keys()],
   base: {
     positioner: {
       position: "relative",
@@ -24,16 +24,18 @@ export const flyoutRecipe = defineSlotRecipe({
       },
     },
     closeTrigger: {
+      display: "flex",
       p: 2,
       position: "absolute",
       top: 2,
       right: 2,
       borderRadius: "md",
       cursor: "pointer",
-      backgroundColor: { base: "inherit", _hover: "bg.emphasized" },
-    },
-    closeTriggerIcon: {
-      color: "fg.default!",
+      bgColor: {
+        base: "inherit",
+        _hover: "bg.subtle",
+      },
+      _focus: { outline: "none" },
     },
     title: {
       p: 4,

--- a/src/components/core/Flyout/Flyout.recipe.ts
+++ b/src/components/core/Flyout/Flyout.recipe.ts
@@ -25,10 +25,10 @@ export const flyoutRecipe = defineSlotRecipe({
     },
     closeTrigger: {
       display: "flex",
-      p: 2,
       position: "absolute",
-      top: 2,
-      right: 2,
+      top: 3,
+      right: 3,
+      p: 2,
       borderRadius: "md",
       cursor: "pointer",
       bgColor: {

--- a/src/components/core/Flyout/Flyout.recipe.ts
+++ b/src/components/core/Flyout/Flyout.recipe.ts
@@ -4,7 +4,7 @@ import { defineSlotRecipe } from "@pandacss/dev";
 export const flyoutRecipe = defineSlotRecipe({
   className: "flyout",
   description: "The styles for the Flyout component",
-  slots: [...popoverAnatomy.keys()],
+  slots: popoverAnatomy.keys(),
   base: {
     positioner: {
       position: "relative",

--- a/src/components/core/Flyout/Flyout.tsx
+++ b/src/components/core/Flyout/Flyout.tsx
@@ -84,7 +84,7 @@ const Flyout = ({
               onClick={onClose}
               className={classNames.closeTrigger}
             >
-              <Icon className={classNames.closeTriggerIcon}>
+              <Icon color="fg.default">
                 <CloseIcon />
               </Icon>
             </PrimitiveFlyoutCloseTrigger>

--- a/src/components/core/Modal/Modal.recipe.ts
+++ b/src/components/core/Modal/Modal.recipe.ts
@@ -83,12 +83,13 @@ export const modalRecipe = defineSlotRecipe({
       },
     },
     closeTrigger: {
+      display: "flex",
       cursor: "pointer",
       borderRadius: "md",
       pos: "absolute",
       top: 2,
       right: 2,
-      p: 3,
+      p: 2,
       bgColor: {
         base: "inherit",
         _hover: "bg.subtle",

--- a/src/components/core/Modal/Modal.recipe.ts
+++ b/src/components/core/Modal/Modal.recipe.ts
@@ -87,8 +87,8 @@ export const modalRecipe = defineSlotRecipe({
       cursor: "pointer",
       borderRadius: "md",
       pos: "absolute",
-      top: 2,
-      right: 2,
+      top: 3,
+      right: 3,
       p: 2,
       bgColor: {
         base: "inherit",

--- a/src/components/core/Toast/Toast.recipe.ts
+++ b/src/components/core/Toast/Toast.recipe.ts
@@ -6,6 +6,7 @@ export const toastRecipe = defineSlotRecipe({
   slots: ["closeTrigger", "title", "description"],
   base: {
     closeTrigger: {
+      display: "flex",
       position: "absolute",
       cursor: "pointer",
       color: "fg.muted",

--- a/src/components/core/Toast/Toast.tsx
+++ b/src/components/core/Toast/Toast.tsx
@@ -27,7 +27,7 @@ const Toast = ({ title, description, onClose, variant, ...rest }: Props) => {
           onClick={onClose}
           aria-label="Close Toast"
         >
-          <Icon h={4} w={4}>
+          <Icon size="sm">
             <FiX />
           </Icon>
         </panda.button>


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/15knCtgI/399-ui-close-trigger-updates

Apply `display: flex` to all closeTrigger recipes to prevent the additional height from being applied.

## Test Steps

1. Verify on all components: Flyout, Toast, Modal, Drawer
