### PR TITLE
Update animate state control for `Collapse`

### DIFF
--- a/.changeset/real-suns-attend.md
+++ b/.changeset/real-suns-attend.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": minor
+---
+
+Add control for `Collapse` initial animation on mount

--- a/src/components/utility/Collapse/Collapse.tsx
+++ b/src/components/utility/Collapse/Collapse.tsx
@@ -12,6 +12,7 @@ import type { ReactElement, ReactNode } from "react";
 
 export interface Props extends FlexProps {
   label?: string;
+  animateOnMount?: boolean;
   icon?: ReactElement;
   isOpen?: boolean;
   onOpen?: () => void;
@@ -26,6 +27,7 @@ export interface Props extends FlexProps {
  */
 const Collapse = ({
   label,
+  animateOnMount = false,
   icon,
   isOpen: isOpenProp,
   onOpen,
@@ -76,7 +78,7 @@ const Collapse = ({
           {icon ?? defaultIcon}
         </Icon>
       </Button>
-      <AnimatePresence>
+      <AnimatePresence initial={animateOnMount}>
         {isOpen && (
           <motion.div
             style={{ overflow: "hidden" }}


### PR DESCRIPTION
## Description

##### Task link: https://...

Hot fix for `Collapse` animation control. When `isOpen` state is set to true on mount, animation used to always render, but that is not always ideal. This change allows for control over that option.

## Test Steps

1) Send it.
