### PR TITLE
Update disabled tab trigger styles

### DIFF
--- a/.changeset/eighty-sheep-thank.md
+++ b/.changeset/eighty-sheep-thank.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Update disabled tab trigger styles

--- a/src/components/core/Tabs/Tabs.recipe.ts
+++ b/src/components/core/Tabs/Tabs.recipe.ts
@@ -62,6 +62,7 @@ export const tabsRecipe = defineSlotRecipe({
         },
       },
       _disabled: {
+        color: "fg.disabled",
         cursor: "not-allowed",
         _hover: {
           color: "fg.subtle",

--- a/src/components/core/Tabs/Tabs.recipe.ts
+++ b/src/components/core/Tabs/Tabs.recipe.ts
@@ -65,7 +65,7 @@ export const tabsRecipe = defineSlotRecipe({
         color: "fg.disabled",
         cursor: "not-allowed",
         _hover: {
-          color: "fg.subtle",
+          color: "fg.disabled",
         },
       },
     },

--- a/src/lib/panda/semanticTokens.ts
+++ b/src/lib/panda/semanticTokens.ts
@@ -61,8 +61,8 @@ const semanticTokens = defineSemanticTokens({
       },
       disabled: {
         value: {
-          base: "{colors.neutral.200}",
-          _dark: "{colors.neutral.800}",
+          base: "{colors.neutral.300}",
+          _dark: "{colors.neutral.600}",
         },
       },
     },


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/jjnSxb0d/425-hard-to-see-difference-between-disabled-and-inactive-tabs-eg-sell-vs-activity-when-on-buy-tab-%F0%9F%90%A7

Changed the disabled tabs trigger styles to have a color of `fg.disabled`

## Test Steps

1. Check styling on example apps. The text is hard to read with the `fg.disabled` semantic token, but not unreadable.