### PR TITLE
Allow downstream control over `Flyout` content

### DIFF
--- a/.changeset/silent-feet-care.md
+++ b/.changeset/silent-feet-care.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": minor
+---
+
+Update available props for `Flyout` to include `contentProps` for ease of overrides downstream

--- a/src/components/core/Flyout/Flyout.tsx
+++ b/src/components/core/Flyout/Flyout.tsx
@@ -15,19 +15,23 @@ import {
 import { flyout } from "generated/panda/recipes";
 import { useDisclosure, useIsClient } from "lib/hooks";
 
-import type { PrimitiveFlyoutProps } from "components/primitives";
+import type {
+  PrimitiveFlyoutProps,
+  PrimitiveFlyoutContentProps,
+} from "components/primitives";
 import type { ReactNode } from "react";
 
 export interface Props extends PrimitiveFlyoutProps {
   trigger?: ReactNode;
   title?: ReactNode;
+  contentProps?: PrimitiveFlyoutContentProps;
   children: ReactNode;
 }
 
 /**
  * Core UI flyout.
  */
-const Flyout = ({ trigger, title, children, ...rest }: Props) => {
+const Flyout = ({ trigger, title, contentProps, children, ...rest }: Props) => {
   const { isOpen, onClose, onToggle } = useDisclosure();
 
   const classNames = flyout();
@@ -49,7 +53,10 @@ const Flyout = ({ trigger, title, children, ...rest }: Props) => {
       )}
 
       <PrimitiveFlyoutPositioner className={classNames.positioner}>
-        <PrimitiveFlyoutContent className={classNames.content}>
+        <PrimitiveFlyoutContent
+          className={classNames.content}
+          {...contentProps}
+        >
           <PrimitiveFlyoutArrow className={classNames.arrow}>
             <PrimitiveFlyoutArrowTip className={classNames.arrowTip} />
           </PrimitiveFlyoutArrow>


### PR DESCRIPTION
## Description

Added `contentProps` to allow for more granular control over layout and style of `Flyout` content downstream.

## Test Steps

1) Verify that styles are updated according when using `contentProps` in `Flyout` component. Check both storybook and example apps.
