### PR TITLE
Add `jsxFactory` to docs and example apps

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,6 +15,7 @@ import { defineConfig } from "@pandacss/dev";
 
 const pandaConfig = defineConfig({
   preflight: true,
+  jsxFramework: "react",
   presets: ["@pandacss/dev/presets", anirefPreset],
   include: ["src/**/*.{ts,tsx}"],
   outdir: "src/generated/panda",
@@ -34,6 +35,8 @@ module.exports = {
 ```
 
 There is no need to install `postcss` as an explicit dependency in your project, the config will be picked up by the UI library bundle.
+
+You may want to customize the config snippets above to your liking. Treat them as a starting point.
 
 4. Create a CSS file and import it into your project. You can name the CSS file anything you want, just make sure you import it early in your project. For example:
 

--- a/examples/next/panda.config.ts
+++ b/examples/next/panda.config.ts
@@ -8,6 +8,7 @@ import { defineConfig } from "@pandacss/dev";
  */
 const pandaConfig = defineConfig({
   preflight: true,
+  jsxFramework: "react",
   presets: ["@pandacss/dev/presets", anirefPreset],
   include: ["src/**/*.{ts,tsx}"],
   outdir: "src/generated/panda",

--- a/examples/next/postcss.config.js
+++ b/examples/next/postcss.config.js
@@ -1,23 +1,16 @@
 // based on Next.js PostCSS default: https://nextjs.org/docs/pages/building-your-application/configuring/post-css#customizing-plugins
 module.exports = {
-  plugins:
-    process.env.NODE_ENV === "production"
-      ? [
-          "@pandacss/dev/postcss",
-          "postcss-flexbugs-fixes",
-          [
-            "postcss-preset-env",
-            {
-              autoprefixer: {
-                flexbox: "no-2009",
-              },
-              stage: 3,
-              features: {
-                "custom-properties": false,
-              },
-            },
-          ],
-        ]
-      : // no transformations in development
-        [],
+  plugins: {
+    "@pandacss/dev/postcss": {},
+    "postcss-flexbugs-fixes": {},
+    "postcss-preset-env": {
+      autoprefixer: {
+        flexbox: "no-2009",
+      },
+      stage: 3,
+      features: {
+        "custom-properties": false,
+      },
+    },
+  },
 };

--- a/examples/vite-react/panda.config.ts
+++ b/examples/vite-react/panda.config.ts
@@ -8,6 +8,7 @@ import { defineConfig } from "@pandacss/dev";
  */
 const pandaConfig = defineConfig({
   preflight: true,
+  jsxFramework: "react",
   presets: ["@pandacss/dev/presets", anirefPreset],
   include: ["src/**/*.{ts,tsx}"],
   outdir: "src/generated/panda",


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/yfRgF84L/329-update-ui-lib-docs-and-examples-with-jsxfactory-specified

Recent Panda versions caused the omission of `jsxFactory` to cause issues in JSX-based projects. They were added here to the documentation, as well as the example apps.

## Test Steps

- Verify documentation looks good
- Verify example apps render styles correctly
