### PR TITLE
Update increment/decrement icon colors for `NumberInput`

### DIFF
--- a/.changeset/kind-elephants-wave.md
+++ b/.changeset/kind-elephants-wave.md
@@ -1,0 +1,5 @@
+---
+"@animareflection/ui": patch
+---
+
+Update default `Icon` color for increment and decrement triggers in `NumberInput`

--- a/src/components/core/NumberInput/NumberInput.recipe.ts
+++ b/src/components/core/NumberInput/NumberInput.recipe.ts
@@ -18,7 +18,7 @@ const stepperTriggerStyles = {
   h: "100%",
   color: {
     base: "fg.default",
-    _disabled: "fg.muted",
+    _disabled: "fg.disabled",
   },
   borderRadius: "sm",
 };

--- a/src/components/core/NumberInput/NumberInput.stories.tsx
+++ b/src/components/core/NumberInput/NumberInput.stories.tsx
@@ -25,6 +25,7 @@ export const Addons: Story = {
       max={5}
       step={0.1}
       stepper
+      disabled
     />
   ),
 };

--- a/src/components/core/NumberInput/NumberInput.stories.tsx
+++ b/src/components/core/NumberInput/NumberInput.stories.tsx
@@ -25,7 +25,6 @@ export const Addons: Story = {
       max={5}
       step={0.1}
       stepper
-      disabled
     />
   ),
 };

--- a/src/components/core/NumberInput/NumberInput.tsx
+++ b/src/components/core/NumberInput/NumberInput.tsx
@@ -92,13 +92,19 @@ const NumberInput = ({
           </PrimitiveNumberInputAddon>
         )}
         {stepper && (
-          <PrimitiveNumberInputControl>
+          <PrimitiveNumberInputControl className="group">
             <PrimitiveNumberInputDecrementTrigger>
               <Icon color="inherit">
                 <FiMinus />
               </Icon>
             </PrimitiveNumberInputDecrementTrigger>
-            <panda.div w="1px" h="75%" mx={0.5} my="auto" bgColor="gray.600" />
+            <panda.div
+              w="1px"
+              h="75%"
+              mx={0.5}
+              my="auto"
+              bgColor={{ base: "fg.default", _groupDisabled: "fg.disabled" }}
+            />
             <PrimitiveNumberInputIncrementTrigger>
               <Icon color="inherit">
                 <FiPlus />

--- a/src/components/core/NumberInput/NumberInput.tsx
+++ b/src/components/core/NumberInput/NumberInput.tsx
@@ -94,13 +94,13 @@ const NumberInput = ({
         {stepper && (
           <PrimitiveNumberInputControl>
             <PrimitiveNumberInputDecrementTrigger>
-              <Icon>
+              <Icon color="inherit">
                 <FiMinus />
               </Icon>
             </PrimitiveNumberInputDecrementTrigger>
             <panda.div w="1px" h="75%" mx={0.5} my="auto" bgColor="gray.600" />
             <PrimitiveNumberInputIncrementTrigger>
-              <Icon>
+              <Icon color="inherit">
                 <FiPlus />
               </Icon>
             </PrimitiveNumberInputIncrementTrigger>


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/DJXk5Cs8/357-update-number-input-icon-colors

Fixed stepper icons to use inherited colors by default.

## Test Steps

1) Verify that style changes are appropriate.
